### PR TITLE
Add Support for Older Robot Framework Versions (5.0+), Update CI & Improve Docs

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.13"]
-        robotframework-version: ["4.0.3", "7.2.2"]
+        robotframework-version: ["5.0", "7.2.2"]
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        robotframework-version: ["4.0.3", "4.1.3", "5.0.1", "6.0.2", "6.1.1", "7.0.1", "7.1.1", "7.2.2"]
+        robotframework-version: ["5.0.1", "6.0.2", "6.1.1", "7.0.1", "7.1.1", "7.2.2"]
       #pabot-version: ["4.1"]
       #dependencylib-version: ["4.0"]
     steps:

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -4,23 +4,62 @@ on:
   push:
     branches:
       - main
+      - '**'
     tags:
       - "v*"
   pull_request:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
-  test:
-    name: Run Tests
+  smoke_tests:
+    name: Run Smoke Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.13"]
+        robotframework-version: ["4.0.3", "7.2.2"]
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+ 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "robotframework==${{ matrix.robotframework-version }}"
+
+      - name: Install package
+        run: pip install -e .[dev]
+
+      - name: Run tests with pytest
+        run: pytest tests/
+
+      - run: echo "🍏 Test job's status is ${{ job.status }}."
+
+  release_test:
+    name: Run Release Tests (Full Matrix)
+    needs: smoke_tests
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        robotframework-version: ["7.0.1", "7.1.1", "7.2.2"]
+        robotframework-version: ["4.0.3", "4.1.3", "5.0.1", "6.0.2", "6.1.1", "7.0.1", "7.1.1", "7.2.2"]
       #pabot-version: ["4.1"]
       #dependencylib-version: ["4.0"]
     steps:
@@ -67,8 +106,10 @@ jobs:
 
   release:
     name: Build and Release
-    needs: test
+    needs: release_test
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 - [Introduction](#introduction)
 - [Versioning](#versioning)
+- [Dependencies](#dependencies)
 - [Installation](#installation)
 - [How define dependencies with DependencyLibrary](#how-define-dependencies-with-dependencylibrary)
 - [Using DependencySolver](#using-dependencysolver)
@@ -41,6 +42,18 @@ refer to section [Using With Pabot](#using-with-pabot).
 
 This library\'s version numbers follow the [SemVer 2.0.0
 specification](https://semver.org/spec/v2.0.0.html).
+
+## Dependencies
+
+To function correctly, **DependencySolver** requires the following versions:
+
+- **Python** >= 3.10  
+- **Robot Framework** >= 5.0  
+- **robotframework-dependencylibrary** >= 4.0  
+
+Additionally, for parallel test execution, you can optionally use:  
+
+- **robotframework-pabot** > 4.1  
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -234,8 +234,9 @@ Additionally, you could use tags also (but only static, not dynamic tags):
 robot --prerunmodifier DependencySolver.depsol:-i:tagC <other_robot_commands> <your_test_folder>
 ```
 
-You can also use shortcut `depsol` directly. This actually calls `robot` with
-`--prerunmodifier`.
+You can also use shortcut `depsol` directly. This internally calls `robot` 
+with `--prerunmodifier` option. When using this shortcut, all options 
+recognized by `depsol` are passed to `--prerunmodifier` instead of `robot`.
 
 ```cmd
 depsol -t "test C" <other_robot_commands> <your_test_folder>
@@ -245,6 +246,18 @@ Or
 depsol -i "tagC" <other_robot_commands> <your_test_folder>
 ```
 These commands will have the same effect as the two commands mentioned above.
+
+**Note:** If you call `robot` directly, `<other_robot_commands>` should not 
+include the options `--test`, `--suite`, `--include` or `--exclude`, as they 
+will be executed before `--prerunmodifier`. This will cause **depsol** to 
+function incorrectly. Instead, pass these options to `--prerunmodifier`, 
+using `:` as a separator instead of a space. If the test name contains spaces, 
+enclose it in `""`.
+
+For example:
+```cmd
+robot --prerunmodifier DependencySolver.depsol:-i:tagC:-t:"Test B" <your_test_folder>
+```
 
 For more options and help, please run
 
@@ -258,6 +271,8 @@ depsol --help
 - **depsol.pabot.txt**: A file for use with [Pabot](https://pabot.org/), detailing how the selected tests can be run in parallel while respecting dependencies.
 
 ## Using with Pabot
+
+Please, read [Using DependencySolver](#using-dependencysolver) at first.
 
 If you want to run tests with Pabot, you need at least version 4.1.0 of the 
 [robotframework-pabot](https://pypi.org/project/robotframework-pabot/) library.
@@ -291,6 +306,9 @@ like this:
 
 ## Contributing
 
-If you would like to request a new feature or modification to existing functionality, or report a bug, you can open an issue on [GitHub](https://github.com/joonaskuisma/robotframework-dependencysolver/issues). For any issues, please create a bug report and reference the version in question. 
+If you would like to request a new feature or modification to existing 
+functionality, or report a bug, you can open an issue on [GitHub](https://github.com/joonaskuisma/robotframework-dependencysolver/issues). 
+For any issues, please create a bug report and reference the version in question. 
 
-If you want to contribute and participate in the project, please read the [Developer Guide](README.dev.md) file first.
+If you want to contribute and participate in the project, please read the 
+[Developer Guide](README.dev.md) file first.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "robotframework-dependencysolver"
 dynamic = ["version"]
 dependencies = [
-  "robotframework>=7.0",
+  "robotframework>=4.0",
   "robotframework-dependencylibrary>=4.0",
 ]
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "robotframework-dependencysolver"
 dynamic = ["version"]
 dependencies = [
-  "robotframework>=4.0",
+  "robotframework>=5.0",
   "robotframework-dependencylibrary>=4.0",
 ]
 requires-python = ">=3.10"

--- a/src/DependencySolver/solver.py
+++ b/src/DependencySolver/solver.py
@@ -12,22 +12,16 @@ from robot.utils import Matcher
 from ._version import __version__
 from .sort_ordering import sort_by_output_xml
 
-#TODO:
-# Add 6.0 robot support
 
 rf_version = tuple(map(int, robot.__version__.split(".")))
 
 if rf_version >= (7, 0):
-    suite_name_attr = "full_name"
+    name_attr = "full_name"
 else:
-    suite_name_attr = "longname"
+    name_attr = "longname"
 
-
-def get_suite_name(suite):
-    return getattr(suite, suite_name_attr, "Unknown")
-
-def get_test_name(suite):
-    return getattr(suite, suite_name_attr, "Unknown")
+def get_name(item):
+    return getattr(item, name_attr, "Unknown")
 
 
 os.system('color')
@@ -278,6 +272,7 @@ class DependencyTestCase:
     def __init__(self, name: str, full_name: str, id: str, tags: list[str], dependencies: TestDependency) -> None:
         self.name = name
         self.full_name = full_name
+        self.longname = full_name   # This is for Robot < 7.0
         self.id = id
         self.tags = tags
         self.dependencies = dependencies
@@ -311,11 +306,11 @@ class ReRunTests(ResultVisitor):
 
     def visit_test(self, test: TestCase) -> None:
         if test.status == 'FAIL':
-            self.failed_tests.append(get_test_name(test))
+            self.failed_tests.append(get_name(test))
         elif test.status == 'SKIP':
-            self.skipped_tests.append(get_test_name(test))
+            self.skipped_tests.append(get_name(test))
         elif test.status == 'PASS':
-            self.passed_tests.append(get_test_name(test))
+            self.passed_tests.append(get_name(test))
         super().visit_test(test)
 
     def end_result(self, result) -> None:
@@ -384,8 +379,22 @@ class DependencySolver(SuiteVisitor):
         return logger
 
 
+    def _name_from_source_legacy(self, name: str) -> str:
+        if '__' in name:
+            name = name.split('__', 1)[1] or name
+        name = name.replace('_', ' ').strip()
+        return name.title() if name.islower() else name
+    
+
+    def _get_long_name(self, name: str) -> str:
+        if rf_version >= (7, 0):
+            return '.'.join([TestSuite.name_from_source(n) for n in name.split('.')])
+        else:
+            return '.'.join([self._name_from_source_legacy(n) for n in name.split('.')])
+
+
     def _matcher(self, name: str, list_of_names: list[str]) -> list[str]:
-        long_name = '.'.join([TestSuite.name_from_source(n) for n in name.split('.')])
+        long_name = self._get_long_name(name)
         return [value for value in list_of_names if Matcher(f'*.{long_name}').match(value) or Matcher(long_name).match(value)]
 
 
@@ -395,13 +404,15 @@ class DependencySolver(SuiteVisitor):
 
         def _go_to_sub_suites(list_of_suites, tests=[]):
             for suite_dependency in list_of_suites:
-                if self.suites[suite_dependency.full_name].suites:
-                    tests += _go_to_sub_suites(self.suites[suite_dependency.full_name].suites, tests)
+                if self.suites[get_name(suite_dependency)].suites:
+                    tests += _go_to_sub_suites(self.suites[get_name(suite_dependency)].suites, tests)
                 else:
-                    tests += self.suites[suite_dependency.full_name].tests
+                    tests += self.suites[get_name(suite_dependency)].tests
             return tests
 
         test_name_list = self._matcher(test_name, self.test_cases)
+        print("name", test_name)
+        print("cases", self.test_cases)
         if not test_name_list:
             message = f"\'Depends On Test\' keyword refers to test {repr(test_name)} that does not exist. Check your spelling."
             raise RecursionError(message)
@@ -409,8 +420,6 @@ class DependencySolver(SuiteVisitor):
         if len(test_name_list) > 1:
             if parent:
                 self.logger.warning(f"Dependence in test {repr(parent)} is {repr(test_name)} which is not unambiguous but refers to the following tests: {repr(test_name_list)}")
-            else:
-                self.logger.warning("Ei printata tässä tilanteessa!")
 
         for t_name in test_name_list:
             id = self.test_cases[t_name].id
@@ -444,8 +453,8 @@ class DependencySolver(SuiteVisitor):
                 for d in transformed_dependencies:
                     depends_these_tests = self.suites[d].tests or _go_to_sub_suites(self.suites[d].suites)
                     for test_dependency in depends_these_tests:
-                        self.logger.debug(f"Transformed dependency: {repr(t_name)} -> {repr(test_dependency.full_name)}")
-                        relation_chain = self._solve_dependencies(test_dependency.full_name, relation_chain=relation_chain, loop_check_mode=loop_check_mode, parent=t_name)
+                        self.logger.debug(f"Transformed dependency: {repr(t_name)} -> {repr(get_name(test_dependency))}")
+                        relation_chain = self._solve_dependencies(get_name(test_dependency), relation_chain=relation_chain, loop_check_mode=loop_check_mode, parent=t_name)
 
         return relation_chain
 
@@ -484,16 +493,16 @@ class DependencySolver(SuiteVisitor):
                 parent_dependencies.append(new_dep)
         
         for sub_suite in suite.suites:
-            if sub_suite.full_name in self.suites:
+            if get_name(sub_suite) in self.suites:
                 message = (
-                    f"Suite name: {repr(sub_suite.full_name)} is duplicated with locations: "
-                    f"{repr(sub_suite.full_name)} and {repr(self.suites[sub_suite.full_name].full_name)}. "
+                    f"Suite name: {repr(get_name(sub_suite))} is duplicated with locations: "
+                    f"{repr(get_name(sub_suite))} and {repr(get_name(self.suites[get_name(sub_suite)]))}. "
                     "Could not solve dependencies."
                 )
                 raise NameError(message)
             else:
-                self.suites[sub_suite.full_name] = sub_suite
-            self.logger.debug(f"Investigating subsuite {repr(sub_suite.full_name)}")
+                self.suites[get_name(sub_suite)] = sub_suite
+            self.logger.debug(f"Investigating subsuite {repr(get_name(sub_suite))}")
             self._find_suites(sub_suite, parent_dependencies)
             self._find_tests(sub_suite, parent_dependencies)
         
@@ -511,7 +520,7 @@ class DependencySolver(SuiteVisitor):
                 dependencies = self._find_dependencies(test.setup)
             if suite_setup_dependencies:
                 self.logger.debug(
-                    f"Merging dependencies in test {repr(test.full_name)} because {repr(suite.full_name)} "
+                    f"Merging dependencies in test {repr(get_name(test))} because {repr(get_name(suite))} "
                     "or its parent suite has 'Suite Setup' with 'Depends On' keyword."
                 )
                 tests = dependencies.tests[:]
@@ -521,17 +530,17 @@ class DependencySolver(SuiteVisitor):
                     suites.extend(suite_setup.suites)
                 dependencies = TestDependency(tests, suites)
                 self.logger.debug(
-                    f"Test {repr(test.full_name)} has dependencies for tests: {repr(dependencies.tests)} "
+                    f"Test {repr(get_name(test))} has dependencies for tests: {repr(dependencies.tests)} "
                     f"and suites: {repr(dependencies.suites)}"
                 )
             if test.name in [tc for tc in self.test_cases.values()]:
                 message = (
-                    f"Test name: {repr(test.full_name)} is duplicated with ids: {repr(test.id)} "
-                    f"and {repr(self.test_cases[test.full_name].id)}. Could not solve dependencies."
+                    f"Test name: {repr(get_name(test))} is duplicated with ids: {repr(test.id)} "
+                    f"and {repr(self.test_cases[get_name(test)].id)}. Could not solve dependencies."
                 )
                 raise NameError(message)
-            self.test_cases[test.full_name] = DependencyTestCase(
-                test.name, test.full_name, test.id, test.tags, dependencies
+            self.test_cases[get_name(test)] = DependencyTestCase(
+                test.name, get_name(test), test.id, test.tags, dependencies
             )
 
 
@@ -574,32 +583,29 @@ class DependencySolver(SuiteVisitor):
             if TagPatterns(tag).match(t.tags):
                 tag_found = True
                 if option == 'include':
-                    #self.tc_by_include.append(t.full_name)
-                    self.logger.debug(f'Requested test {repr(t.full_name)} because of --include option: {repr(tag)}')
+                    self.logger.debug(f'Requested test {repr(get_name(t))} because of --include option: {repr(tag)}')
                 elif option == 'exclude':
-                    #self.tc_by_exclude.append(t.full_name)
-                    self.logger.debug(f'Not requested test {repr(t.full_name)} because of --exclude option: {repr(tag)}')
+                    self.logger.debug(f'Not requested test {repr(get_name(t))} because of --exclude option: {repr(tag)}')
                 elif option == 'exclude_explicit':
-                    #self.tc_by_exclude_explicit.append(t.full_name)
-                    self.logger.debug(f'Not requested test {repr(t.full_name)} in any case, because of --exclude_explicit option: {repr(tag)}')
-                output.append(t.full_name)
+                    self.logger.debug(f'Not requested test {repr(get_name(t))} in any case, because of --exclude_explicit option: {repr(tag)}')
+                output.append(get_name(t))
         if not tag_found and option == 'include':
             self.logger.warning(f'Given tag: {repr(tag)} not found from any tests. Check your spelling.')
         return output
 
 
     def _check_suite(self, suite_name: str, suite_found: bool = False) -> None:
-        long_name = '.'.join([TestSuite.name_from_source(n) for n in suite_name.split('.')])
+        long_name = self._get_long_name(suite_name)
         for s in self.suites:
             if Matcher(f'*{long_name}').match(s) or Matcher(f'*.{long_name}').match(s):
                 suite_found = True
                 for sub_s in self.suites[s].suites:
                     self.logger.debug(f'{repr(suite_name)} has subsuite {repr(sub_s.name)}. Investigating...')
-                    self._check_suite(sub_s.full_name, suite_found=suite_found)
+                    self._check_suite(get_name(sub_s), suite_found=suite_found)
 
                 for t in self.suites[s].tests:
-                    self.logger.debug(f'Requested test {repr(t.full_name)} because of subsuite or direct --suite option: {repr(suite_name)}')
-                    self.tc_by_suite.append(t.full_name)
+                    self.logger.debug(f'Requested test {repr(get_name(t))} because of subsuite or direct --suite option: {repr(suite_name)}')
+                    self.tc_by_suite.append(get_name(t))
 
         if not suite_found:
             message = f"Argument: {repr(suite_name)} not found in test suites."
@@ -609,11 +615,10 @@ class DependencySolver(SuiteVisitor):
     def _check_test(self, test_name: str) -> list[str]:
         test_case_found = False
         output = []
-        long_name = '.'.join([TestSuite.name_from_source(n) for n in test_name.split('.')])
+        long_name = self._get_long_name(test_name)
         self.logger.debug(f'Requested test {repr(test_name)} directly.')
         for t in self.test_cases:
             if Matcher(f'*.{long_name}').match(t) or Matcher(long_name).match(t):
-                #self.tc_by_test.append(t)
                 output.append(t)
                 test_case_found = True
 
@@ -676,7 +681,7 @@ class DependencySolver(SuiteVisitor):
         if self.desired_tests:
             if self.args.reverse:
                 find_these_tests = self.desired_tests
-                self.desired_tests = [t.full_name for t in self.test_cases.values()]
+                self.desired_tests = [get_name(t) for t in self.test_cases.values()]
 
             self.logger.debug(f'These are tests which user requested: {repr(self.desired_tests)}')
             self.logger.info('Starting relation chain checking...')
@@ -805,8 +810,8 @@ class DependencySolver(SuiteVisitor):
             for s in self.test_cases[r].dependencies.suites:
                 for matching_s in self._matcher(s, self.suites):
                     for t_in_s in self.suites[matching_s].tests:
-                        self.test_cases[r].add_solved_test_dependencies(t_in_s.full_name)
-                        self.test_cases[t_in_s.full_name].add_direct_precondition(r)
+                        self.test_cases[r].add_solved_test_dependencies(get_name(t_in_s))
+                        self.test_cases[get_name(t_in_s)].add_direct_precondition(r)
 
         self._define_groups()
 
@@ -838,12 +843,12 @@ class DependencySolver(SuiteVisitor):
         """When suite starts, check if it is main suite/folder. If it is, loops through all test cases and finds all relation chains.
         After then it defines which test to execute."""
         if not self.error_occurs:
-            self.logger.debug(f"Started suite: {repr(suite.full_name)}")
+            self.logger.debug(f"Started suite: {repr(get_name(suite))}")
         if not self.check_done:
             self.logger.info("Starting to explore the dependencies...")
-            self.main_suite_full_name = suite.full_name
+            self.main_suite_full_name = get_name(suite)
             try:
-                self.suites[suite.full_name] = suite
+                self.suites[get_name(suite)] = suite
                 self._find_suites(suite)
                 self._define_running_tests()
             except (NameError, RecursionError) as err:
@@ -856,13 +861,13 @@ class DependencySolver(SuiteVisitor):
 
     def end_suite(self, suite: TestSuite) -> None:
         """Selects the tests and suites to be executed."""
-        suite.tests = [t for t in suite.tests if t.full_name in self.list_of_running_tests_names]
+        suite.tests = [t for t in suite.tests if get_name(t) in self.list_of_running_tests_names]
         for t in suite.tests:
-            self.logger.debug(f"Test {repr(t.full_name)} will be executed.")
+            self.logger.debug(f"Test {repr(get_name(t))} will be executed.")
         suite.suites = [s for s in suite.suites if s.test_count > 0]
         for s in suite.suites:
-            self.logger.debug(f"Suite {repr(s.full_name)} will be executed.")
+            self.logger.debug(f"Suite {repr(get_name(s))} will be executed.")
         if not self.error_occurs:
-            self.logger.debug(f"Finishing suite: {repr(suite.full_name)}")
-        if not self.args.without_timestamps and suite.full_name == self.main_suite_full_name:
+            self.logger.debug(f"Finishing suite: {repr(get_name(suite))}")
+        if not self.args.without_timestamps and get_name(suite) == self.main_suite_full_name:
             self.logger.info("All dependencies resolved in %s seconds." % str(time.time() - self.start_time))

--- a/tests/data_1/__init__.robot
+++ b/tests/data_1/__init__.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Test Tags    ALL    data_1
+#Test Tags    ALL    data_1

--- a/tests/data_1/suiteA.robot
+++ b/tests/data_1/suiteA.robot
@@ -1,34 +1,34 @@
 *** Settings ***
-Test Tags    A    all
+#Test Tags    A    all
 Library  DependencyLibrary
 
 *** Test Cases ***
 TestA1
-    [Tags]    A1    t1
+    [Tags]    A1    t1    all    A
     Log    message=test
 
 TestA2
-    [Tags]    A2    t1
+    [Tags]    A2    t1    all    A
     [Setup]    Depends On Test    name=TestA1
     Log    message=test
 
 TestA3
-    [Tags]    A3    t2
+    [Tags]    A3    t2    all    A
     [Setup]    Depends On Test    name=TestA2
     Log    message=test
 
 TestA4
-    [Tags]    A4    t2
+    [Tags]    A4    t2    all    A
     [Setup]    Depends On Test    name=TestA2
     Log    message=test
 
 TestA5
-    [Tags]    A5    t3
+    [Tags]    A5    t3    all    A
     [Setup]    Run Keywords    Depends On Test    name=TestA3
     ...    AND    Depends On Test    TestA4
     Log    message=test
 
 TestA6
-    [Tags]    A6    t3
+    [Tags]    A6    t3    all    A
     [Setup]    Depends On Test    TestA5
     Log    message=test

--- a/tests/data_1/suiteB.robot
+++ b/tests/data_1/suiteB.robot
@@ -1,37 +1,37 @@
 *** Settings ***
 #Resource    resource.robot
-Test Tags    testB    all
+#Test Tags    testB    all
 Library  DependencyLibrary
 
 *** Test Cases ***
 TestB1
-    [Tags]    B1    t1
+    [Tags]    B1    t1    all    testB
     [Setup]    Depends On Test    name=TestA5
     Log    message=test
 
 TestB2
-    [Tags]    B2    t1
+    [Tags]    B2    t1    all    testB
     [Setup]    Depends On Test    name=TestB1
     Log    message=test
 
 TestB3
-    [Tags]    B3    t2
+    [Tags]    B3    t2    all    testB
     [Setup]    Depends On Test    name=TestB2
     Log    message=test
 
 TestB4
-    [Tags]    B4    t2
+    [Tags]    B4    t2    all    testB
     [Setup]    Depends On Test    name=TestB2
     Log    message=test
 
 TestB5
-    [Tags]    B5    t3
+    [Tags]    B5    t3    all    testB
     [Setup]    Run Keywords    Depends On Test    name=TestB3
     ...    AND    Depends On Test    TestB4
     Log    message=test
 
 TestB6
-    [Tags]    B6    t3
+    [Tags]    B6    t3    all    testB
     [Setup]    Depends On Test    TestB5
     Log    message=test
 

--- a/tests/data_10/01__suite_A.robot
+++ b/tests/data_10/01__suite_A.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    resource.robot
-Test Tags    A
+#Test Tags    A
 
 *** Test Cases ***
 Test A1

--- a/tests/data_10/01__suite_A_copy.robot
+++ b/tests/data_10/01__suite_A_copy.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    resource.robot
-Test Tags    A
+#Test Tags    A
 
 *** Test Cases ***
 Test A1

--- a/tests/data_10/__init__.robot
+++ b/tests/data_10/__init__.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Test Tags    ALL    data_10
+#Test Tags    ALL    data_10

--- a/tests/data_11/01__suite_A.robot
+++ b/tests/data_11/01__suite_A.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    resource.robot
-Test Tags    A
+#Test Tags    A
 Suite Setup    Log    message=This depends on nothing
 
 *** Test Cases ***

--- a/tests/data_11/02__subsuite_a/01__subsubsuite_a/01__suite_B.robot
+++ b/tests/data_11/02__subsuite_a/01__subsubsuite_a/01__suite_B.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    B
+#Test Tags    B
 Test Setup    Depends On Test    name=Test B1
 
 *** Test Cases ***

--- a/tests/data_11/02__subsuite_a/01__subsubsuite_a/02__suite_C.robot
+++ b/tests/data_11/02__subsuite_a/01__subsubsuite_a/02__suite_C.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    C
+#Test Tags    C
 
 *** Test Cases ***
 Test C1

--- a/tests/data_11/02__subsuite_a/02__suite_D.robot
+++ b/tests/data_11/02__subsuite_a/02__suite_D.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../resource.robot
-Test Tags    D
+#Test Tags    D
 
 *** Test Cases ***
 Test D1

--- a/tests/data_11/02__subsuite_a/03__subsubsuite_b/01__suite_E.robot
+++ b/tests/data_11/02__subsuite_a/03__subsubsuite_b/01__suite_E.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    E
+#Test Tags    E
 
 *** Test Cases ***
 Test E1

--- a/tests/data_11/02__subsuite_a/03__subsubsuite_b/02__suite_F.robot
+++ b/tests/data_11/02__subsuite_a/03__subsubsuite_b/02__suite_F.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    F
+#Test Tags    F
 
 *** Test Cases ***
 Test F1

--- a/tests/data_11/02__subsuite_a/04__suite_G.robot
+++ b/tests/data_11/02__subsuite_a/04__suite_G.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../resource.robot
-Test Tags    G
+#Test Tags    G
 
 *** Test Cases ***
 Test G1

--- a/tests/data_11/03__suite_H.robot
+++ b/tests/data_11/03__suite_H.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    resource.robot
-Test Tags    H
+#Test Tags    H
 
 *** Test Cases ***
 Test H1

--- a/tests/data_11/04__suite_I.robot
+++ b/tests/data_11/04__suite_I.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    resource.robot
-Test Tags    I
+#Test Tags    I
 
 *** Test Cases ***
 Test I1

--- a/tests/data_11/05__subsuite_b/01__suite_J.robot
+++ b/tests/data_11/05__subsuite_b/01__suite_J.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../resource.robot
-Test Tags    J
+#Test Tags    J
 
 *** Test Cases ***
 Test J1

--- a/tests/data_11/05__subsuite_b/02__subsubsuite_c/01__suite_K.robot
+++ b/tests/data_11/05__subsuite_b/02__subsubsuite_c/01__suite_K.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    K
+#Test Tags    K
 
 *** Test Cases ***
 Test K1

--- a/tests/data_11/05__subsuite_b/02__subsubsuite_c/02__suite_L.robot
+++ b/tests/data_11/05__subsuite_b/02__subsubsuite_c/02__suite_L.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    L
+#Test Tags    L
 
 *** Test Cases ***
 Test L1

--- a/tests/data_11/05__subsuite_b/03__suite_M.robot
+++ b/tests/data_11/05__subsuite_b/03__suite_M.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../resource.robot
-Test Tags    M
+#Test Tags    M
 
 *** Test Cases ***
 Test M1

--- a/tests/data_11/05__subsuite_b/04__subsubsuite_d/01__suite_N.robot
+++ b/tests/data_11/05__subsuite_b/04__subsubsuite_d/01__suite_N.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    N
+#Test Tags    N
 
 *** Test Cases ***
 Test N1

--- a/tests/data_11/05__subsuite_b/04__subsubsuite_d/02__suite_O.robot
+++ b/tests/data_11/05__subsuite_b/04__subsubsuite_d/02__suite_O.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    O
+#Test Tags    O
 Test Setup    Depends On Suite    name=Suite K
 
 *** Test Cases ***

--- a/tests/data_11/06__suite_P.robot
+++ b/tests/data_11/06__suite_P.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    resource.robot
-Test Tags    P
+#Test Tags    P
 #Suite Setup    Depends On Suite    suite O
 #Suite Setup    Depends On Suite    name=subsubsuite 1
 

--- a/tests/data_11/__init__.robot
+++ b/tests/data_11/__init__.robot
@@ -1,3 +1,3 @@
 *** Settings ***
-Test Tags    ALL    data_7
+#Test Tags    ALL    data_7
 Suite Setup    Log    main setup

--- a/tests/data_12/01__suite_A.robot
+++ b/tests/data_12/01__suite_A.robot
@@ -1,34 +1,34 @@
 *** Settings ***
-Test Tags    A    all
+#Test Tags    A    all
 Library  DependencyLibrary
 
 *** Test Cases ***
 Test A 1
-    [Tags]    A1    t1
+    [Tags]    A1    t1    ALL
     Log    message=test
 
 Test A 2 long name
-    [Tags]    A2    t1
+    [Tags]    A2    t1    ALL
     [Setup]    Depends On Test    name=Test A 1
     Log    message=test
 
 Test_A_3_Name
-    [Tags]    A3    t2
+    [Tags]    A3    t2    ALL
     [Setup]    Depends On Test    name=Test A 2 long name
     Log    message=test
 
 Test__A4
-    [Tags]    A4    t2
+    [Tags]    A4    t2    ALL
     [Setup]    Depends On Test    name=Test A 2 long name
     Log    message=test
 
 TestA5 name
-    [Tags]    A5    t3
+    [Tags]    A5    t3    ALL
     [Setup]    Run Keywords    Depends On Test    name=Test_A_3_Name
     ...    AND    Depends On Test    Test__A4
     Log    message=test
 
 TestA6
-    [Tags]    A6    t3
+    [Tags]    A6    t3    ALL
     [Setup]    Depends On Test    tESTa5 NAME
     Log    message=test

--- a/tests/data_12/01__suite_A.robot
+++ b/tests/data_12/01__suite_A.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Test Tags    A    all
+Library  DependencyLibrary
+
+*** Test Cases ***
+Test A 1
+    [Tags]    A1    t1
+    Log    message=test
+
+Test A 2 long name
+    [Tags]    A2    t1
+    [Setup]    Depends On Test    name=Test A 1
+    Log    message=test
+
+Test_A_3_Name
+    [Tags]    A3    t2
+    [Setup]    Depends On Test    name=Test A 2 long name
+    Log    message=test
+
+Test__A4
+    [Tags]    A4    t2
+    [Setup]    Depends On Test    name=Test A 2 long name
+    Log    message=test
+
+TestA5 name
+    [Tags]    A5    t3
+    [Setup]    Run Keywords    Depends On Test    name=Test_A_3_Name
+    ...    AND    Depends On Test    Test__A4
+    Log    message=test
+
+TestA6
+    [Tags]    A6    t3
+    [Setup]    Depends On Test    tESTa5 NAME
+    Log    message=test

--- a/tests/data_12/__init__.robot
+++ b/tests/data_12/__init__.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Test Tags    ALL    data_12
+#Test Tags    ALL    data_12

--- a/tests/data_12/__init__.robot
+++ b/tests/data_12/__init__.robot
@@ -1,0 +1,2 @@
+*** Settings ***
+Test Tags    ALL    data_12

--- a/tests/data_2/__init__.robot
+++ b/tests/data_2/__init__.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Test Tags    ALL    data_2
+#Test Tags    ALL    data_2

--- a/tests/data_2/suiteC.robot
+++ b/tests/data_2/suiteC.robot
@@ -1,20 +1,20 @@
 *** Settings ***
 #Resource    resource.robot
-Test Tags    testC
+#Test Tags    testC
 Library  DependencyLibrary
 
 *** Test Cases ***
 TestC1
-    [Tags]    C1
+    [Tags]    C1    testC
     [Setup]    Depends On Test    name=TestC2
     Log    message=test
 
 TestC2
-    [Tags]    C2
+    [Tags]    C2    testC
     [Setup]    Depends On Test    name=TestC1
     Log    message=test
 
 TestC3
-    [Tags]    C3
+    [Tags]    C3    testC
     [Setup]    Depends On Test    name=TestC3
     Log    message=test

--- a/tests/data_3/__init__.robot
+++ b/tests/data_3/__init__.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Test Tags    ALL    data_3
+#Test Tags    ALL    data_3

--- a/tests/data_3/suiteC.robot
+++ b/tests/data_3/suiteC.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 #Resource    resource.robot
-Test Tags    testC
+#Test Tags    testC
 Library  DependencyLibrary
 
 *** Test Cases ***

--- a/tests/data_4/__init__.robot
+++ b/tests/data_4/__init__.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Test Tags    ALL    data_4
+#Test Tags    ALL    data_4

--- a/tests/data_4/suiteD.robot
+++ b/tests/data_4/suiteD.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Test Tags    D
+#Test Tags    D
 Library  DependencyLibrary
 
 *** Test Cases ***

--- a/tests/data_4/suiteE.robot
+++ b/tests/data_4/suiteE.robot
@@ -1,15 +1,15 @@
 *** Settings ***
-Test Tags    E
+#Test Tags    E
 Library  DependencyLibrary
 
 *** Test Cases ***
 TestE1
-    [Tags]    E1
+    [Tags]    E1    E
     [Setup]    Depends On Test    name=TestD2
     Log    message=test
 
 TestE2
-    [Tags]    E2
+    [Tags]    E2    E
     [Setup]    Depends On Suite    name=suiteD
     Log    message=test
 

--- a/tests/data_5/__init__.robot
+++ b/tests/data_5/__init__.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Test Tags    ALL    data_5
+#Test Tags    ALL    data_5

--- a/tests/data_5/suiteD.robot
+++ b/tests/data_5/suiteD.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Test Tags    D
+#Test Tags    D
 Library  DependencyLibrary
 
 *** Test Cases ***

--- a/tests/data_5/suiteE.robot
+++ b/tests/data_5/suiteE.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Test Tags    E
+#Test Tags    E
 Library  DependencyLibrary
 
 *** Test Cases ***

--- a/tests/data_6/__init__.robot
+++ b/tests/data_6/__init__.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Test Tags    ALL    data_6
+#Test Tags    ALL    data_6

--- a/tests/data_6/subsuite/suiteE.robot
+++ b/tests/data_6/subsuite/suiteE.robot
@@ -1,6 +1,6 @@
 *** Settings ***
-Test Tags    G
-Library    DependencySolver
+#Test Tags    G
+Library    DependencyLibrary
 
 *** Test Cases ***
 TestG1

--- a/tests/data_6/suiteD.robot
+++ b/tests/data_6/suiteD.robot
@@ -1,12 +1,12 @@
 *** Settings ***
-Test Tags    D
+#Test Tags    D
 Library  DependencyLibrary
 
 *** Test Cases ***
 TestD1
-    [Tags]    D1
+    [Tags]    D1    D
     Log    message=test
 
 TestD2
-    [Tags]    D2
+    [Tags]    D2    D
     Log    message=test

--- a/tests/data_6/suiteE.robot
+++ b/tests/data_6/suiteE.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Test Tags    E
+#Test Tags    E
 Library  DependencyLibrary
 
 *** Test Cases ***

--- a/tests/data_7/01__suite_A.robot
+++ b/tests/data_7/01__suite_A.robot
@@ -1,13 +1,13 @@
 *** Settings ***
 Resource    resource.robot
-Test Tags    A
+#Test Tags    A
 
 *** Test Cases ***
 Test A1
-    [Tags]    A1
+    [Tags]    A1    ALL
     Log    message=test
 
 Test A2
-    [Tags]    A2
+    [Tags]    A2    ALL
     [Setup]    Depends On Test    name=Test A1
     Log    message=test

--- a/tests/data_7/02__subsuite_a/01__subsubsuite_a/01__suite_B.robot
+++ b/tests/data_7/02__subsuite_a/01__subsubsuite_a/01__suite_B.robot
@@ -1,19 +1,19 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    B
+#Test Tags    B
 
 *** Test Cases ***
 Test B1
-    [Tags]    B1
+    [Tags]    B1    ALL
     [Setup]    Depends On Suite    name=suite A
     Log    message=test
 
 Test B2
-    [Tags]    B2
+    [Tags]    B2    ALL
     [Setup]    Depends On Test    name=Test A1
     Log    message=test
     Fail    msg=This will fail
 
 Test B3
-    [Tags]    B3
+    [Tags]    B3    ALL
     Log    message=test

--- a/tests/data_7/02__subsuite_a/01__subsubsuite_a/02__suite_C.robot
+++ b/tests/data_7/02__subsuite_a/01__subsubsuite_a/02__suite_C.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    C
+#Test Tags    C
 
 *** Test Cases ***
 Test C1
-    [Tags]    C1
+    [Tags]    C1    ALL
     Log    message=test

--- a/tests/data_7/02__subsuite_a/02__suite_D.robot
+++ b/tests/data_7/02__subsuite_a/02__suite_D.robot
@@ -1,9 +1,9 @@
 *** Settings ***
 Resource    ../resource.robot
-Test Tags    D
+#Test Tags    D
 
 *** Test Cases ***
 Test D1
-    [Tags]    D1
+    [Tags]    D1    ALL
     [Setup]    Depends On Test    name=Test B2
     Log    message=test

--- a/tests/data_7/02__subsuite_a/03__subsubsuite_b/01__suite_E.robot
+++ b/tests/data_7/02__subsuite_a/03__subsubsuite_b/01__suite_E.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    E
+#Test Tags    E
 
 *** Test Cases ***
 Test E1
-    [Tags]    E1
+    [Tags]    E1    ALL
     Log    message=test

--- a/tests/data_7/02__subsuite_a/03__subsubsuite_b/02__suite_F.robot
+++ b/tests/data_7/02__subsuite_a/03__subsubsuite_b/02__suite_F.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    F
+#Test Tags    F
 
 *** Test Cases ***
 Test F1
-    [Tags]    F1
+    [Tags]    F1    ALL
     Log    message=test

--- a/tests/data_7/02__subsuite_a/04__suite_G.robot
+++ b/tests/data_7/02__subsuite_a/04__suite_G.robot
@@ -1,9 +1,9 @@
 *** Settings ***
 Resource    ../resource.robot
-Test Tags    G
+#Test Tags    G
 
 *** Test Cases ***
 Test G1
-    [Tags]    G1
+    [Tags]    G1    ALL
     [Setup]    Depends On Suite    name=suite B
     Log    message=test

--- a/tests/data_7/03__suite_H.robot
+++ b/tests/data_7/03__suite_H.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    resource.robot
-Test Tags    H
+#Test Tags    H
 
 *** Test Cases ***
 Test H1
-    [Tags]    H1
+    [Tags]    H1    ALL
     Log    message=test

--- a/tests/data_7/04__suite_I.robot
+++ b/tests/data_7/04__suite_I.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    resource.robot
-Test Tags    I
+#Test Tags    I
 
 *** Test Cases ***
 Test I1
-    [Tags]    I1
+    [Tags]    I1    ALL
     Log    message=test

--- a/tests/data_7/05__subsuite_b/01__suite_J.robot
+++ b/tests/data_7/05__subsuite_b/01__suite_J.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    ../resource.robot
-Test Tags    J
+#Test Tags    J
 
 *** Test Cases ***
 Test J1
-    [Tags]    J1
+    [Tags]    J1    ALL
     Log    message=test

--- a/tests/data_7/05__subsuite_b/02__subsubsuite_c/01__suite_K.robot
+++ b/tests/data_7/05__subsuite_b/02__subsubsuite_c/01__suite_K.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    K
+#Test Tags    K
 
 *** Test Cases ***
 Test K1
-    [Tags]    K1
+    [Tags]    K1    ALL
     Log    message=test

--- a/tests/data_7/05__subsuite_b/02__subsubsuite_c/02__suite_L.robot
+++ b/tests/data_7/05__subsuite_b/02__subsubsuite_c/02__suite_L.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    L
+#Test Tags    L
 
 *** Test Cases ***
 Test L1
-    [Tags]    L1
+    [Tags]    L1    ALL
     Log    message=test

--- a/tests/data_7/05__subsuite_b/03__suite_M.robot
+++ b/tests/data_7/05__subsuite_b/03__suite_M.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    ../resource.robot
-Test Tags    M
+#Test Tags    M
 
 *** Test Cases ***
 Test M1
-    [Tags]    M1
+    [Tags]    M1    ALL
     Log    message=test

--- a/tests/data_7/05__subsuite_b/04__subsubsuite_d/01__suite_N.robot
+++ b/tests/data_7/05__subsuite_b/04__subsubsuite_d/01__suite_N.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    N
+#Test Tags    N
 
 *** Test Cases ***
 Test N1
-    [Tags]    N1
+    [Tags]    N1    ALL
     Log    message=test

--- a/tests/data_7/05__subsuite_b/04__subsubsuite_d/02__suite_O.robot
+++ b/tests/data_7/05__subsuite_b/04__subsubsuite_d/02__suite_O.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    ../../resource.robot
-Test Tags    O
+#Test Tags    O
 
 *** Test Cases ***
 Test O1
-    [Tags]    O1
+    [Tags]    O1    ALL
     Log    message=test

--- a/tests/data_7/06__suite_P.robot
+++ b/tests/data_7/06__suite_P.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource    resource.robot
-Test Tags    P
+#Test Tags    P
 
 *** Test Cases ***
 Test P1
-    [Tags]    P1
+    [Tags]    P1    ALL
     Log    message=test

--- a/tests/data_7/__init__.robot
+++ b/tests/data_7/__init__.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Test Tags    ALL    data_7
+#Test Tags    ALL    data_7

--- a/tests/data_8/__init__.robot
+++ b/tests/data_8/__init__.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Test Tags    ALL    data_8
+#Test Tags    ALL    data_8

--- a/tests/data_8/suiteA.robot
+++ b/tests/data_8/suiteA.robot
@@ -1,37 +1,37 @@
 *** Settings ***
-Test Tags    A
+#Test Tags    A
 Library  DependencyLibrary
 
 *** Test Cases ***
 TestA0
-    [Tags]    A0
+    [Tags]    A0    ALL
     Log    message=test
 
 TestA1
-    [Tags]    A1
+    [Tags]    A1    ALL
     Log    message=test
 
 TestA2
-    [Tags]    A2
+    [Tags]    A2    ALL
     Log    message=test
 
 TestA3
-    [Tags]    A3
+    [Tags]    A3    ALL
     [Setup]    Run Keywords    Depends On Test    name=TestA1
     ...    AND    Depends On Test    TestA2
     Log    message=test
 
 TestA4
-    [Tags]    A4
+    [Tags]    A4    ALL
     [Setup]    Depends On Test    name=TestA0
     Log    message=test
 
 TestA5
-    [Tags]    A5
+    [Tags]    A5    ALL
     Log    message=test
 
 TestA6
-    [Tags]    A6
+    [Tags]    A6    ALL
     [Setup]    Depends On Test    TestA5
     Log    message=test
 

--- a/tests/data_8/suiteB.robot
+++ b/tests/data_8/suiteB.robot
@@ -1,34 +1,34 @@
 *** Settings ***
 #Resource    resource.robot
-Test Tags    B
+#Test Tags    B
 Library  DependencyLibrary
 
 *** Test Cases ***
 TestB1
-    [Tags]    B1
+    [Tags]    B1    ALL
     Log    message=test
 
 TestB2
-    [Tags]    B2
+    [Tags]    B2    ALL
     Log    message=test
 
 TestB3
-    [Tags]    B3
+    [Tags]    B3    ALL
     Log    message=test
 
 TestB4
-    [Tags]    B4
+    [Tags]    B4    ALL
     [Setup]    Depends On Test    name=TestB3
     Log    message=test
 
 TestB5
-    [Tags]    B5
+    [Tags]    B5    ALL
     [Setup]    Run Keywords    Depends On Test    name=TestB1
     ...    AND    Depends On Test    TestA2
     ...    AND    Depends On Test    TestA0
     Log    message=test
 
 TestB6
-    [Tags]    B6
+    [Tags]    B6    ALL
     Log    message=test
 

--- a/tests/data_9/__init__.robot
+++ b/tests/data_9/__init__.robot
@@ -1,2 +1,2 @@
 *** Settings ***
-Test Tags    ALL    data_9
+#Test Tags    ALL    data_9

--- a/tests/data_9/suiteA.robot
+++ b/tests/data_9/suiteA.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Test Tags    A
+#Test Tags    A
 Library  DependencyLibrary
 
 *** Test Cases ***

--- a/tests/data_9/suiteB.robot
+++ b/tests/data_9/suiteB.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Test Tags    B
+#Test Tags    B
 Test Setup    Depends On Suite    suiteA
 Library  DependencyLibrary
 

--- a/tests/pabot_ordering_references/test_names.txt
+++ b/tests/pabot_ordering_references/test_names.txt
@@ -1,0 +1,8 @@
+{
+--test suite A.Test A 1
+--test suite A.Test A 2 long name #DEPENDS suite A.Test A 1
+--test suite A.Test_A_3_Name #DEPENDS suite A.Test A 2 long name
+--test suite A.Test__A4 #DEPENDS suite A.Test A 2 long name
+--test suite A.TestA5 name #DEPENDS suite A.Test_A_3_Name #DEPENDS suite A.Test__A4
+--test suite A.TestA6 #DEPENDS suite A.TestA5 name
+}

--- a/tests/test_dependency_solver.py
+++ b/tests/test_dependency_solver.py
@@ -234,3 +234,10 @@ class TestClass:
         additional_command = [TESTS_FOLDER + data_folder, '--suite', 'suite O']
         assert check_logs(BASE_COMMAND + additional_command, TESTS_FOLDER + 'test_reflogs/keyword_in_suite_setup.log') == False
         assert check_pabot_ordering(TESTS_FOLDER + 'pabot_ordering_references/keyword_in_suite_setup.txt') == False
+
+
+    def test_different_test_names(self):
+        data_folder =  'data_12/01__suite_A.robot'
+        additional_command = [TESTS_FOLDER + data_folder, '-i', 'ALL']
+        assert check_logs(BASE_COMMAND + additional_command, TESTS_FOLDER + 'test_reflogs/test_names.log') == False
+        assert check_pabot_ordering(TESTS_FOLDER + 'pabot_ordering_references/test_names.txt') == False

--- a/tests/test_reflogs/test_names.log
+++ b/tests/test_reflogs/test_names.log
@@ -1,0 +1,67 @@
+[ INFO ] The following arguments were obtained: ('--include', 'ALL', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ DEBUG ] Started suite: 'suite A'
+[ INFO ] Starting to explore the dependencies...
+[ DEBUG ] Requested test 'suite A.Test A 1' because of --include option: 'ALL'
+[ DEBUG ] Requested test 'suite A.Test A 2 long name' because of --include option: 'ALL'
+[ DEBUG ] Requested test 'suite A.Test_A_3_Name' because of --include option: 'ALL'
+[ DEBUG ] Requested test 'suite A.Test__A4' because of --include option: 'ALL'
+[ DEBUG ] Requested test 'suite A.TestA5 name' because of --include option: 'ALL'
+[ DEBUG ] Requested test 'suite A.TestA6' because of --include option: 'ALL'
+[ DEBUG ] These are tests which user requested: ['suite A.Test A 1', 'suite A.Test A 2 long name', 'suite A.Test_A_3_Name', 'suite A.Test__A4', 'suite A.TestA5 name', 'suite A.TestA6']
+[ INFO ] Starting relation chain checking...
+[ DEBUG ] Checking relation chain for test 'suite A.Test A 1'
+[ DEBUG ] Adding 'suite A.Test A 1'
+[ DEBUG ] Checking relation chain for test 'suite A.Test A 2 long name'
+[ DEBUG ] Dependency: 'suite A.Test A 2 long name' -> 'Test A 1'
+[ DEBUG ] Adding 'suite A.Test A 2 long name'
+[ DEBUG ] 'suite A.Test A 1' is already added.
+[ DEBUG ] Checking relation chain for test 'suite A.Test_A_3_Name'
+[ DEBUG ] Dependency: 'suite A.Test_A_3_Name' -> 'Test A 2 long name'
+[ DEBUG ] Dependency: 'suite A.Test A 2 long name' -> 'Test A 1'
+[ DEBUG ] Adding 'suite A.Test_A_3_Name'
+[ DEBUG ] 'suite A.Test A 2 long name' is already added.
+[ DEBUG ] 'suite A.Test A 1' is already added.
+[ DEBUG ] Checking relation chain for test 'suite A.Test__A4'
+[ DEBUG ] Dependency: 'suite A.Test__A4' -> 'Test A 2 long name'
+[ DEBUG ] Dependency: 'suite A.Test A 2 long name' -> 'Test A 1'
+[ DEBUG ] Adding 'suite A.Test__A4'
+[ DEBUG ] 'suite A.Test A 2 long name' is already added.
+[ DEBUG ] 'suite A.Test A 1' is already added.
+[ DEBUG ] Checking relation chain for test 'suite A.TestA5 name'
+[ DEBUG ] Dependency: 'suite A.TestA5 name' -> 'Test_A_3_Name'
+[ DEBUG ] Dependency: 'suite A.Test_A_3_Name' -> 'Test A 2 long name'
+[ DEBUG ] Dependency: 'suite A.Test A 2 long name' -> 'Test A 1'
+[ DEBUG ] Dependency: 'suite A.TestA5 name' -> 'Test__A4'
+[ DEBUG ] Dependency: 'suite A.Test__A4' -> 'Test A 2 long name'
+[ DEBUG ] In test case 'suite A.Test A 2 long name' either the branches merge or it is a loop. Let's explore what we end up with if we start with this test.
+[ DEBUG ] Starting in loop check mode.
+[ DEBUG ] Dependency: 'suite A.Test A 2 long name' -> 'Test A 1'
+[ DEBUG ] It was a merge, so let's exit loop check mode:
+[ DEBUG ] These tests are already check as loop safe: ['suite A.Test A 2 long name', 'suite A.Test A 1']
+[ DEBUG ] Dependency: 'suite A.Test A 2 long name' -> 'Test A 1'
+[ DEBUG ] 'suite A.Test A 1' has already been checked and does not contain a loop.
+[ DEBUG ] Adding 'suite A.TestA5 name'
+[ DEBUG ] 'suite A.Test_A_3_Name' is already added.
+[ DEBUG ] 'suite A.Test A 2 long name' is already added.
+[ DEBUG ] 'suite A.Test A 1' is already added.
+[ DEBUG ] 'suite A.Test__A4' is already added.
+[ DEBUG ] Checking relation chain for test 'suite A.TestA6'
+[ DEBUG ] Dependency: 'suite A.TestA6' -> 'tESTa5 NAME'
+[ DEBUG ] Dependency: 'suite A.TestA5 name' -> 'Test_A_3_Name'
+[ DEBUG ] Dependency: 'suite A.Test_A_3_Name' -> 'Test A 2 long name'
+[ DEBUG ] Dependency: 'suite A.Test A 2 long name' -> 'Test A 1'
+[ DEBUG ] Dependency: 'suite A.TestA5 name' -> 'Test__A4'
+[ DEBUG ] Dependency: 'suite A.Test__A4' -> 'Test A 2 long name'
+[ DEBUG ] 'suite A.Test A 2 long name' has already been checked and does not contain a loop.
+[ DEBUG ] Dependency: 'suite A.Test A 2 long name' -> 'Test A 1'
+[ DEBUG ] 'suite A.Test A 1' has already been checked and does not contain a loop.
+[ DEBUG ] Adding 'suite A.TestA6'
+[ DEBUG ] 'suite A.TestA5 name' is already added.
+[ DEBUG ] 'suite A.Test_A_3_Name' is already added.
+[ DEBUG ] 'suite A.Test A 2 long name' is already added.
+[ DEBUG ] 'suite A.Test A 1' is already added.
+[ DEBUG ] 'suite A.Test__A4' is already added.
+[ INFO ] 6 tests would have been chosen. List of test: ['suite A.Test A 1', 'suite A.Test A 2 long name', 'suite A.Test_A_3_Name', 'suite A.Test__A4', 'suite A.TestA5 name', 'suite A.TestA6']
+[ WARNING ] DEBUG mode activated. Emptying test case list...
+[ INFO ] Choosing tests...
+[ DEBUG ] Finishing suite: 'suite A'


### PR DESCRIPTION
### Changes  
- Modified compatibility logic to support Robot Framework 5.0 and later.  
- Adjusted CI pipeline to ensure proper testing across different versions.  
- Enhanced documentation to clarify version support and usage.  

### Why?  
These changes improve backward compatibility, ensuring the tool works with older Robot Framework versions. The updated CI workflow provides better test coverage, and documentation improvements make it easier for users to understand supported versions.  

### Testing  
- Verified changes with different Robot Framework versions in CI.  
- Ran tests locally to confirm expected behavior.  

### Related Issues / Notes  
- Closes #1