### PR TITLE
Add support for --randomize and --ui options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@ env/
 *report.html
 depsol.pabot*.txt
 depsol.log
+depsol.all_dependencies.txt
 .pabotsuitenames
 pabot_results/
 TODO
+.tmp/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To function correctly, **DependencySolver** requires the following versions:
 
 Additionally, for parallel test execution, you can optionally use:  
 
-- **robotframework-pabot** > 4.1  
+- **robotframework-pabot** >= 4.1  
 
 ## Installation
 
@@ -271,6 +271,11 @@ For example:
 ```cmd
 robot --prerunmodifier DependencySolver.depsol:-i:tagC:-t:"Test B" <your_test_folder>
 ```
+
+You can launch the simple UI of the Dependency Solver using the --ui parameter. 
+This interface allows you to select tests for execution through a tree view and visualizes dependencies between tests using arrows.
+
+**Note:** The UI is currently in Beta, so feedback and bug reports are very welcome. Its documentation will also improve over time.
 
 For more options and help, please run
 

--- a/src/DependencySolver/run.py
+++ b/src/DependencySolver/run.py
@@ -34,6 +34,7 @@ def build_command():
         'exclude': args.exclude,
         'exclude_explicit': args.exclude_explicit,
         'rerun': args.rerun,
+        'randomize': args.randomize,
         'reverse': args.reverse,
         'debug': args.debug,
         'without_timestamps': args.without_timestamps,
@@ -51,6 +52,11 @@ def build_command():
             prerun_modifier += f'--{prerun_params}:'
         elif isinstance(values, str) and values:
             prerun_modifier += f'--{prerun_params}:{values}:'
+        elif isinstance(values, tuple) and values:
+            if values[1] is not None:
+                prerun_modifier += f'--{prerun_params}:{values[0]};{str(values[1])}:'
+            else:
+                prerun_modifier += f'--{prerun_params}:{values[0]}:'
         elif isinstance(values, list) and values:
             for value in values:
                 prerun_modifier += f'--{prerun_params}:{value}:'
@@ -65,7 +71,8 @@ def build_command():
     prerun_modifier_cmd = [prerun_call, f'{PROG_NAME}:{prerun_modifier[:-1]}']
     command.extend(prerun_modifier_cmd)
     command.extend(unknown)
-
+    
+    print(command)
     return command
 
 

--- a/src/DependencySolver/run.py
+++ b/src/DependencySolver/run.py
@@ -24,7 +24,7 @@ def build_command():
         prerun_call = '--pabotprerunmodifier'
         unknown.extend(['--testlevelsplit', '--ordering', f'{PROG_CALL}.pabot.txt'])
 
-    if not any(arg for arg in [args.test, args.suite, args.include, args.exclude, args.exclude_explicit, args.rerun]):
+    if not any(arg for arg in [args.test, args.suite, args.include, args.exclude, args.exclude_explicit, args.rerun, args.ui]):
         print(f"WARNING: To use '{PROG_CALL}', please provide a parameter related to test selection, for example '--test' or '--include'. See: '{PROG_CALL} --help'" )
     
     prerun_params = {
@@ -42,6 +42,7 @@ def build_command():
         'consoleloglevel': args.consoleloglevel,
         'src_file': args.src_file,  # type: io.TextIOBase
         'pabotlevel': args.pabotlevel,
+        'ui': args.ui,
     }
 
     command = [args.tool]

--- a/src/DependencySolver/solver.py
+++ b/src/DependencySolver/solver.py
@@ -3,7 +3,6 @@
 
 import argparse
 import logging
-import os  # Tarvitaanko?
 import robot
 import time
 import random

--- a/src/DependencySolver/ui.py
+++ b/src/DependencySolver/ui.py
@@ -1,0 +1,540 @@
+import tkinter as tk
+from tkinter import ttk
+import tkinter.messagebox as messagebox
+
+class TestUI:
+    def __init__(self, root):
+        self.root = root
+        self.root.title("DependencySolver-UI")
+        self.root.protocol("WM_DELETE_WINDOW", self.export_and_close)
+
+        self.tests = {}
+        self.test_order = []
+        self.current_selected_tests = []
+        self.parse_tests_file()
+        self.tooltip = None
+
+        # Menubar
+        menubar = tk.Menu(self.root)
+        filemenu = tk.Menu(menubar, tearoff=0)
+        filemenu.add_command(label="Show Chosen Tests", command=self.update_ui)
+        filemenu.add_command(label="Save and Close", command=self.export_and_close)
+        menubar.add_cascade(label="File", menu=filemenu)
+
+        helpmenu = tk.Menu(menubar, tearoff=0)
+        helpmenu.add_command(label="Info", command=self.show_info)
+        menubar.add_cascade(label="Help", menu=helpmenu)
+        self.root.config(menu=menubar)
+
+        viewmenu = tk.Menu(menubar, tearoff=0)
+        viewmenu.add_command(label="Reset zoom", command=self.reset_zoom)
+        menubar.add_cascade(label="View", menu=viewmenu)
+
+        # Main panel which divides left (Treeview) and right (Canvas) areas
+        self.paned = ttk.PanedWindow(self.root, orient=tk.HORIZONTAL)
+        self.paned.pack(fill=tk.BOTH, expand=True)
+
+        # Treeview-side
+        self.tree_frame = ttk.Frame(self.paned)
+        self.tree = ttk.Treeview(self.tree_frame)
+        self.tree.heading("#0", text="Test Cases")
+        self.tree.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+        self.test_vars = {}
+        self.build_tree()
+        self.paned.add(self.tree_frame, weight=1)
+
+        # Canvas-side (scrollable)
+        self.canvas_frame = ttk.Frame(self.paned)
+        self.canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
+
+        self.canvas_frame.rowconfigure(0, weight=1)
+        self.canvas_frame.columnconfigure(0, weight=1)
+
+        self.canvas = tk.Canvas(self.canvas_frame, bg="white")
+        self.canvas.grid(row=0, column=0, sticky="nsew")
+
+        self.scroll_y = ttk.Scrollbar(self.canvas_frame, orient="vertical", command=self.canvas.yview)
+        self.scroll_y.grid(row=0, column=1, sticky="ns")
+
+        self.scroll_x = ttk.Scrollbar(self.canvas_frame, orient="horizontal", command=self.canvas.xview)
+        self.scroll_x.grid(row=1, column=0, sticky="ew")
+
+        self.canvas.configure(yscrollcommand=self.scroll_y.set, xscrollcommand=self.scroll_x.set)
+        self.paned.add(self.canvas_frame, weight=4)
+
+        self.canvas_toolbar = ttk.Frame(self.canvas_frame)
+        self.canvas_toolbar.place(relx=1.0, x=-30, y=10, anchor="ne")
+
+        ttk.Button(self.canvas_toolbar, text="+", width=2, command=self._on_key_zoom_in).pack(side=tk.LEFT)
+        ttk.Button(self.canvas_toolbar, text="-", width=2, command=self._on_key_zoom_out).pack(side=tk.LEFT)
+        ttk.Button(self.canvas_toolbar, text="⭯", width=2, command=self.reset_zoom).pack(side=tk.LEFT)
+
+        zoom_fit_button = ttk.Button(self.canvas_toolbar, text="Zoom to Fit", command=self.zoom_to_fit)
+        zoom_fit_button.pack(side=tk.LEFT)
+
+        self.zoom_label = ttk.Label(self.canvas_toolbar, text="Zoom: 100%")
+        self.zoom_label.pack(side=tk.LEFT, padx=10)
+
+        # Define fixed zoom levels (as float values)
+        self.zoom_levels = [0.2 + i * 0.1 for i in range(39)]  # 0.2 to 4.0 by 0.1
+        self.canvas_scale = 1.0
+        self.canvas.bind_all("<Control-MouseWheel>", self._on_canvas_zoom)
+
+        # Mouse scroll
+        self.canvas.bind_all("<MouseWheel>", self._on_mousewheel)
+        self.canvas.bind_all("<Shift-MouseWheel>", self._on_shift_mousewheel)
+
+
+    def build_tree(self):
+        self.tree_nodes = {}  # path -> item_id
+        for test_name in self.test_order:
+            parts = test_name.split('.')
+            path = ""
+            parent = ""
+            for i, part in enumerate(parts):
+                path = '.'.join(parts[:i + 1])
+                if path not in self.tree_nodes:
+                    label = part
+                    node_id = self.tree.insert(parent, "end", text=f"[ ] {label}", open=True)
+                    self.tree_nodes[path] = node_id
+                parent = self.tree_nodes[path]
+
+            # Last part is test itself
+            var = tk.BooleanVar()
+            var.set(False)
+            self.test_vars[test_name] = var
+
+            display_text = f"[ ] {parts[-1]}"
+            self.tree.item(self.tree_nodes[path], text=display_text)
+
+            self.tree.tag_bind(test_name, '<Button-1>', lambda e, name=test_name: self.toggle_checkbox(name))
+
+        # Click events on whole tree
+        self.tree.bind("<Button-1>", self.on_tree_click)
+
+
+    def on_tree_click(self, event):
+        item_id = self.tree.identify_row(event.y)
+        if not item_id:
+            return
+
+        full_path = self.get_full_path(item_id)
+
+        # Prevent checkbox toggle if clicked to the far left (on top of expander)
+        if event.x < 20 * len(full_path.split(".")):
+            return
+        
+        # Checking whether the tests include
+        if full_path in self.test_vars:
+            self.toggle_checkbox(full_path)
+        else:
+            self.toggle_group_checkbox(item_id)
+        self.update_ui()
+
+
+    def toggle_checkbox(self, test_name):
+        var = self.test_vars[test_name]
+        var.set(not var.get())
+        item_id = self.tree_nodes[test_name]
+        new_state = "[x]" if var.get() else "[ ]"
+        label = test_name.split('.')[-1]
+        self.tree.item(item_id, text=f"{new_state} {label}")
+
+
+    def toggle_group_checkbox(self, item_id):
+        # Determine the selected status (x or no)
+        current_text = self.tree.item(item_id, "text")
+        new_state = not current_text.strip().startswith("[x]")
+
+        # Update current node
+        self.update_tree_item_checkbox(item_id, new_state)
+
+        # Recursively update all child nodes
+        def update_children_recursive(parent_id):
+            for child_id in self.tree.get_children(parent_id):
+                self.update_tree_item_checkbox(child_id, new_state)
+                update_children_recursive(child_id)
+
+        update_children_recursive(item_id)
+
+
+    def update_tree_item_checkbox(self, item_id, state):
+        full_path = self.get_full_path(item_id)
+        label = self.tree.item(item_id, "text").replace("[x] ", "").replace("[ ] ", "").strip()
+
+        # Update view
+        self.tree.item(item_id, text=f"[x] {label}" if state else f"[ ] {label}")
+
+        # If it is a correct test, update the var
+        if full_path in self.test_vars:
+            self.test_vars[full_path].set(state)
+
+
+
+    def update_checkbox_display_recursive(self, item_id):
+        text = self.tree.item(item_id, "text")
+        full_path = self.get_full_path(item_id)
+        if full_path in self.test_vars:
+            var = self.test_vars[full_path]
+            new_text = text.replace("[x]", "[ ]").replace("[ ]", "[x]" if var.get() else "[ ]")
+            self.tree.item(item_id, text=new_text)
+
+        for child_id in self.tree.get_children(item_id):
+            self.update_checkbox_display_recursive(child_id)
+
+
+    def get_full_path(self, item_id):
+        parts = []
+        while item_id:
+            raw_text = self.tree.item(item_id, "text")
+            clean_text = raw_text.replace("[ ] ", "").replace("[x] ", "")
+            parts.insert(0, clean_text)
+            item_id = self.tree.parent(item_id)
+        return '.'.join(parts)
+
+
+    def parse_tests_file(self):
+        test_data = """
+        --test Tests.suite A.Test A5
+        {
+        --test Tests.suite A.Test A1
+        --test Tests.suite A.Test A2 #DEPENDS Tests.suite A.Test A1
+        --test Tests.suite A.Test A3 #DEPENDS Tests.suite A.Test A2
+        --test Tests.suite A.Test A4 #DEPENDS Tests.suite A.Test A3
+        }
+        {
+        --test Tests.suite B.Test A6
+        --test Tests.suite B.Test A7 #DEPENDS Tests.suite B.Test A6
+        --test Tests.suite B.Test A8 #DEPENDS Tests.suite B.Test A6 
+        --test Tests.suite B.Test A9 #DEPENDS Tests.suite B.Test A6 
+        --test Tests.suite B.Test A10 #DEPENDS Tests.suite B.Test A7
+        --test Tests.suite B.Test A11 #DEPENDS Tests.suite B.Test A7
+        --test Tests.suite B.Test A12 #DEPENDS Tests.suite B.Test A8 
+        --test Tests.suite B.Test A13 #DEPENDS Tests.suite B.Test A8 #DEPENDS Tests.suite B.Test A6
+        --test Tests.suite B.Test A14 #DEPENDS Tests.suite B.Test A9 #DEPENDS Tests.suite B.Test A6
+        }
+        {
+        --test Tests.suite C.Test C1
+        --test Tests.suite C.Test C2
+        --test Tests.suite C.Test C3
+        --test Tests.suite C.Test C4 #DEPENDS Tests.suite C.Test C1 #DEPENDS Tests.suite C.Test C2 #DEPENDS Tests.suite C.Test C3
+        }
+        --test Tests.Test D1
+        --test Tests.Test D2
+        --test Test E1
+        """
+        
+        lines = test_data.strip().split('\n')
+        for line in lines:
+            line = line.strip()
+            if line.startswith('--test'):
+                data = line.split("--test ")[1].split("#DEPENDS")
+                test_name = data[0].strip()
+                deps = []
+                for n in range(1, len(data)):
+                    deps.append(data[n].strip())
+                print("test name:", test_name)
+                self.tests[test_name] = {"name": test_name, "dependencies": deps}
+                self.test_order.append(test_name)
+            
+
+    def build_check_buttons(self):
+        # Create checkboxes for all tests
+        self.checkbuttons = {}
+        for idx, test_name in enumerate(self.test_order):
+            var = tk.BooleanVar()
+            cb = tk.Checkbutton(self.check_frame, text=test_name, variable=var)
+            cb.grid(row=idx, sticky='w')
+            self.checkbuttons[test_name] = var
+
+
+    def draw_dependencies(self, selected_tests_original):
+        self.current_selected_tests = selected_tests_original.copy()
+
+        self.canvas.delete("all")
+
+        x_spacing = 200
+        y_spacing = 80
+        x_start = 100
+        y_start = 50
+        row_spacing = 200
+
+        positions = {}
+
+        # 1. Adding prerequisites to the selection
+        def collect_with_dependencies(test, collected):
+            if test in collected:
+                return
+            collected.add(test)
+            for dep in self.tests.get(test, {}).get("dependencies", []):
+                if dep in self.tests:
+                    collect_with_dependencies(dep, collected)
+
+        full_selected = set()
+        for test in selected_tests_original:
+            collect_with_dependencies(test, full_selected)
+
+        # 2. Group division
+        visited = set()
+        groups = []
+
+        def dfs_group(test, group):
+            if test in visited:
+                return
+            visited.add(test)
+            group.add(test)
+            for dep in self.tests.get(test, {}).get("dependencies", []):
+                if dep in full_selected:
+                    dfs_group(dep, group)
+            for t in full_selected:
+                if test in self.tests.get(t, {}).get("dependencies", []):
+                    dfs_group(t, group)
+
+        ungrouped = full_selected.copy()
+        while ungrouped:
+            group = set()
+            dfs_group(next(iter(ungrouped)), group)
+            groups.append(group)
+            ungrouped -= group
+
+        color_palette = ["lightblue", "lightgreen", "lightyellow", "lightpink", "lightgray", "#FFD580", "#B0E0E6"]
+        current_y = y_start
+
+        for idx, group in enumerate(groups):
+            group_color = color_palette[idx % len(color_palette)]
+            # Delete a group if none of its tests are in the original selection
+            if not any(t in selected_tests_original for t in group):
+                continue
+
+            # Depth levels
+            group_level_map = {}
+            def compute_level(test, visited):
+                if test in visited:
+                    return 0
+                visited.add(test)
+                if not self.tests[test]["dependencies"]:
+                    return 0
+                return 1 + max(compute_level(dep, visited.copy()) for dep in self.tests[test]["dependencies"] if dep in full_selected)
+
+            for test in group:
+                group_level_map[test] = compute_level(test, set())
+
+            level_tests = {}
+            for test in group:
+                level = group_level_map[test]
+                level_tests.setdefault(level, []).append(test)
+
+            max_height = max(len(tests) for tests in level_tests.values())
+            level_y_offsets = {lvl: current_y for lvl in level_tests}
+
+            # Title
+            self.canvas.create_text(x_start - 100, current_y - 100, text=f"Group {idx + 1}", anchor="w", font=("Arial", 14, "bold"))
+
+            # Let's draw tests
+            for level in sorted(level_tests):
+                for test in sorted(level_tests[level]):
+                    x = x_start + level * x_spacing
+                    y = level_y_offsets[level]
+                    positions[test] = (x, y)
+                    box = self.canvas.create_rectangle(x - 60, y - 20, x + 60, y + 20, fill=group_color)
+                    display_text = self.shorten_text_to_fit(test.split('.')[-1], 100 * self.canvas_scale)
+                    label = self.canvas.create_text(x, y, text=display_text)
+
+                    self.canvas.tag_bind(box, "<Enter>", lambda e, t=test: self.show_tooltip(e, t))
+                    self.canvas.tag_bind(box, "<Leave>", self.hide_tooltip)
+                    self.canvas.tag_bind(label, "<Enter>", lambda e, t=test: self.show_tooltip(e, t))
+                    self.canvas.tag_bind(label, "<Leave>", self.hide_tooltip)
+                    level_y_offsets[level] += y_spacing
+
+            # Let's draw arrows
+            for test in group:
+                for dep in self.tests[test]["dependencies"]:
+                    if dep in group:
+                        x1, y1 = positions[test]
+                        x2, y2 = positions[dep]
+                        self.canvas.create_line(x1 - 60, y1, x2 + 60, y2, arrow=tk.LAST)
+
+            current_y += (max_height + 1) * y_spacing + row_spacing
+
+        self.canvas.scale("all", 0, 0, self.canvas_scale, self.canvas_scale)
+        self.canvas.config(scrollregion=self.canvas.bbox("all"))
+
+
+    def shorten_text_to_fit(self, text, max_width, font=("TkDefaultFont", 10)):
+        test_id = self.canvas.create_text(0, 0, text=text, font=font, anchor="nw", tags="temp")
+        bbox = self.canvas.bbox(test_id)
+        self.canvas.delete(test_id)
+
+        if not bbox:
+            return text  # fallback if font measuring fails
+
+        width = bbox[2] - bbox[0]
+        if width <= max_width:
+            return text
+
+        # Shorten the text until it fits
+        for i in range(len(text), 0, -1):
+            shortened = text[:i] + "..."
+            test_id = self.canvas.create_text(0, 0, text=shortened, font=font, anchor="nw", tags="temp")
+            bbox = self.canvas.bbox(test_id)
+            self.canvas.delete(test_id)
+
+            if bbox and (bbox[2] - bbox[0]) <= max_width:
+                return shortened
+
+        return "..."  # fallback if nothing works
+
+
+    def reset_zoom(self):
+        self.canvas_scale = 1.0
+        self._update_zoom_label()
+        self.draw_dependencies(self.current_selected_tests)
+
+
+    def show_info(self):
+        messagebox.showinfo("Instructions", "\n- Select tests from the tree on the left.\n- Selected tests and their dependencies will be drawn on the right.\n- If you select a test, its prerequisites will be automatically selected.\n- Close and save selections by clicking \"Save and Close\".")
+
+
+    def show_tooltip(self, event, text):
+        if self.tooltip:
+            self.canvas.delete(self.tooltip)
+            self.tooltip = None
+        x = self.canvas.canvasx(event.x)
+        y = self.canvas.canvasy(event.y)
+        self.tooltip = self.canvas.create_text(x + 10, y + 10, anchor="nw", text=text, tag="tooltip", fill="black", font=("Arial", 10))
+
+
+    def hide_tooltip(self, event=None):
+        if self.tooltip:
+            self.canvas.delete(self.tooltip)
+            self.tooltip = None
+
+
+    def _on_mousewheel(self, event):
+        self.canvas.yview_scroll(-1 * (event.delta // 120), "units")
+
+
+    def _on_shift_mousewheel(self, event):
+        self.canvas.xview_scroll(-1 * (event.delta // 120), "units")
+
+
+    def _on_key_zoom_in(self):
+        current = self.canvas_scale
+        for level in self.zoom_levels:
+            if level > current:
+                self._zoom_canvas_direct(level)
+                break
+
+
+    def _on_key_zoom_out(self):
+        current = self.canvas_scale
+        for level in reversed(self.zoom_levels):
+            if level < current:
+                self._zoom_canvas_direct(level)
+                break
+
+
+    def _zoom_canvas_direct(self, new_scale):
+        if new_scale == self.canvas_scale:
+            return
+
+        self.canvas_scale = new_scale
+        self._update_zoom_label()
+        self.draw_dependencies(self.current_selected_tests)
+        self.canvas.config(scrollregion=self.canvas.bbox("all"))
+
+    
+    def _on_canvas_zoom(self, event):
+        zoom_factor = 1.1 if event.delta > 0 else 0.9
+        old_scale = self.canvas_scale
+        new_scale = old_scale * zoom_factor
+        new_scale = max(0.2, min(4.0, new_scale))
+
+        if abs(new_scale - old_scale) < 0.001:
+            return
+
+        canvas_mouse_x = self.canvas.canvasx(event.x)
+        canvas_mouse_y = self.canvas.canvasy(event.y)
+
+        bbox = self.canvas.bbox("all")
+        if not bbox:
+            return
+
+        content_width = bbox[2] - bbox[0]
+        content_height = bbox[3] - bbox[1]
+
+        rel_x = (canvas_mouse_x - bbox[0]) / max(content_width, 1)
+        rel_y = (canvas_mouse_y - bbox[1]) / max(content_height, 1)
+
+        self.canvas_scale = new_scale
+        self._update_zoom_label()
+        self.draw_dependencies(self.current_selected_tests)
+
+        bbox = self.canvas.bbox("all")
+        if bbox:
+            new_width = bbox[2] - bbox[0]
+            new_height = bbox[3] - bbox[1]
+
+            new_x = bbox[0] + rel_x * new_width
+            new_y = bbox[1] + rel_y * new_height
+
+            self.canvas.xview_moveto((new_x - self.canvas.winfo_width() / 2) / max(new_width, 1))
+            self.canvas.yview_moveto((new_y - self.canvas.winfo_height() / 2) / max(new_height, 1))
+
+        self.canvas.config(scrollregion=self.canvas.bbox("all"))
+
+    
+    def zoom_to_fit(self):
+        bbox = self.canvas.bbox("all")
+        if not bbox:
+            return
+
+        canvas_width = self.canvas.winfo_width()
+        canvas_height = self.canvas.winfo_height()
+
+        content_width = bbox[2] - bbox[0]
+        content_height = bbox[3] - bbox[1]
+
+        if content_width == 0 or content_height == 0:
+            return
+
+        scale_x = canvas_width / content_width
+        scale_y = canvas_height / content_height
+
+        fit_scale = min(scale_x, scale_y)
+        fit_scale = max(0.2, min(4.0, fit_scale))
+
+        self.canvas_scale = fit_scale
+        self._update_zoom_label()
+        self.draw_dependencies(self.current_selected_tests)
+
+        self.canvas.xview_moveto(0)
+        self.canvas.yview_moveto(0)
+
+
+
+    def _update_zoom_label(self):
+        percent = int(self.canvas_scale * 100)
+        self.zoom_label.config(text=f"Zoom: {percent}%")
+
+
+    def update_ui(self):
+        selected = [name for name, var in self.test_vars.items() if var.get()]
+        self.draw_dependencies(selected)
+
+
+    def export_and_close(self):
+        selected = [name for name, var in self.test_vars.items() if var.get()]
+        print("Chosen Test Cases:", selected)
+        self.root.destroy()
+
+
+def main():
+    root = tk.Tk()
+    app = TestUI(root)
+    root.geometry("1920x1080")
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/DependencySolver/ui.py
+++ b/src/DependencySolver/ui.py
@@ -3,9 +3,11 @@ from tkinter import ttk
 import tkinter.messagebox as messagebox
 
 from DependencySolver._version import __version__
+from DependencySolver.ui_canvas import DependencyCanvasManager, CanvasView
+from DependencySolver.ui_treeview import TestTreeView
+
 
 class TestUI:
-    # TODO: ADD default values:
     def __init__(self, root, data, default_test_cases):
         self.root = root
         self.root.title(f"DependencySolver-GUI {__version__}")
@@ -14,57 +16,26 @@ class TestUI:
         self.tests = {}
         self.test_order = []
         self.current_selected_tests = []
-        self.all_current_selected_test_cases = []
-        self.parse_tests_file(data)
-        self.tooltip = None
-        self.active_scroll_target = None
         self.default_test_cases = default_test_cases
+        self.test_vars = {}
 
-        # Menubar
-        menubar = tk.Menu(self.root)
-        filemenu = tk.Menu(menubar, tearoff=0)
-        filemenu.add_command(label="Show Chosen Tests", command=self.update_ui)
-        filemenu.add_command(label="Save and Close", command=self.export_and_close)
-        menubar.add_cascade(label="File", menu=filemenu)
+        self.parse_tests_file(data)
 
-        helpmenu = tk.Menu(menubar, tearoff=0)
-        helpmenu.add_command(label="Info", command=self.show_info)
-        menubar.add_cascade(label="Help", menu=helpmenu)
-        self.root.config(menu=menubar)
-
-        viewmenu = tk.Menu(menubar, tearoff=0)
-        viewmenu.add_command(label="Reset zoom", command=self.reset_zoom)
-        menubar.add_cascade(label="View", menu=viewmenu)
-
-        # Main panel which divides left (Treeview) and right (Canvas) areas
         self.paned = ttk.PanedWindow(self.root, orient=tk.HORIZONTAL)
         self.paned.pack(fill=tk.BOTH, expand=True)
 
-        # Treeview container frame
-        self.tree_frame = ttk.Frame(self.paned)
-        self.tree_frame.pack(side=tk.LEFT, fill=tk.Y, padx=10, pady=10, expand=True)
+        # Treeview (left side)
+        self.tree_view = TestTreeView(
+            parent=self.paned,
+            test_order=self.test_order,
+            test_vars=self.test_vars,
+            default_test_cases=self.default_test_cases,
+            on_selection_change=self.update_ui
+        )
+        self.paned.add(self.tree_view.frame, weight=1)
 
-        self.tree_scroll_y = ttk.Scrollbar(self.tree_frame, orient="vertical")
-        self.tree = ttk.Treeview(self.tree_frame, yscrollcommand=self.tree_scroll_y.set)
-        self.tree.heading("#0", text="Test Cases")
-        self.tree.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-
-        self.tree_scroll_y.config(command=self.tree.yview)
-
-        self.tree.grid(row=0, column=0, sticky="nsew")
-        self.tree_scroll_y.grid(row=0, column=1, sticky="ns")
-
-        self.tree_frame.grid_rowconfigure(0, weight=1)
-        self.tree_frame.grid_columnconfigure(0, weight=1)
-
-        self.test_vars = {}
-        self.build_tree()
-        self.paned.add(self.tree_frame, weight=1)
-
-        # Canvas-side (scrollable)
+        # Canvas (right side)
         self.canvas_frame = ttk.Frame(self.paned)
-        self.canvas_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True)
-
         self.canvas_frame.rowconfigure(0, weight=1)
         self.canvas_frame.columnconfigure(0, weight=1)
 
@@ -72,514 +43,114 @@ class TestUI:
         self.canvas.grid(row=0, column=0, sticky="nsew")
 
         self.scroll_y = ttk.Scrollbar(self.canvas_frame, orient="vertical", command=self.canvas.yview)
-        self.scroll_y.grid(row=0, column=1, sticky="ns")
-
         self.scroll_x = ttk.Scrollbar(self.canvas_frame, orient="horizontal", command=self.canvas.xview)
-        self.scroll_x.grid(row=1, column=0, sticky="ew")
-
         self.canvas.configure(yscrollcommand=self.scroll_y.set, xscrollcommand=self.scroll_x.set)
-        self.paned.add(self.canvas_frame, weight=4)
+
+        self.scroll_y.grid(row=0, column=1, sticky="ns")
+        self.scroll_x.grid(row=1, column=0, sticky="ew")
 
         self.canvas_toolbar = ttk.Frame(self.canvas_frame)
         self.canvas_toolbar.place(relx=1.0, x=-30, y=10, anchor="ne")
 
+        self.zoom_label = ttk.Label(self.canvas_toolbar, text="Zoom: 100%")
         self.total_selected_label = tk.Label(self.canvas_toolbar, text="Total Selected Tests: 0", font=("Arial", 10, "italic"))
         self.total_selected_label.pack(side=tk.TOP, padx=10)
-        ttk.Button(self.canvas_toolbar, text="+", width=2, command=self._on_key_zoom_in).pack(side=tk.LEFT)
-        ttk.Button(self.canvas_toolbar, text="-", width=2, command=self._on_key_zoom_out).pack(side=tk.LEFT)
-        ttk.Button(self.canvas_toolbar, text="⭯", width=2, command=self.reset_zoom).pack(side=tk.LEFT)
 
-        zoom_fit_button = ttk.Button(self.canvas_toolbar, text="Zoom to Fit", command=self.zoom_to_fit)
-        zoom_fit_button.pack(side=tk.LEFT)
+        self.canvas_view = CanvasView(self.canvas, self.zoom_label)
+        self.canvas.canvas_view = self.canvas_view
+        self.canvas_view.set_counter_label(self.total_selected_label)
 
-        self.zoom_label = ttk.Label(self.canvas_toolbar, text="Zoom: 100%")
+        ttk.Button(self.canvas_toolbar, text="+", width=2, command=self.canvas_view.zoom_in).pack(side=tk.LEFT)
+        ttk.Button(self.canvas_toolbar, text="-", width=2, command=self.canvas_view.zoom_out).pack(side=tk.LEFT)
+        ttk.Button(self.canvas_toolbar, text="⭯", width=2, command=self.canvas_view.reset_zoom_and_positions).pack(side=tk.LEFT)
+        ttk.Button(self.canvas_toolbar, text="Zoom to Fit", command=self.canvas_view.zoom_to_fit).pack(side=tk.LEFT)
+        ttk.Button(self.canvas_toolbar, text="Undo", command=self.canvas_view.undo).pack(side=tk.LEFT)
+        ttk.Button(self.canvas_toolbar, text="Redo", command=self.canvas_view.redo).pack(side=tk.LEFT)
         self.zoom_label.pack(side=tk.LEFT, padx=10)
 
-        # Define fixed zoom levels (as float values)
-        self.zoom_levels = [0.2 + i * 0.1 for i in range(39)]  # 0.2 to 4.0 by 0.1
-        self.canvas_scale = 1.0
-        self.canvas.bind_all("<Control-MouseWheel>", self._on_canvas_zoom)
+        self.paned.add(self.canvas_frame, weight=4)
 
-        self.tree.bind("<Enter>", lambda e: self._set_scroll_target("tree"))
-        self.tree.bind("<Leave>", lambda e: self._set_scroll_target(None))
+        # Menubar
+        menubar = tk.Menu(self.root)
+        filemenu = tk.Menu(menubar, tearoff=0)
+        #filemenu.add_command(label="Show Chosen Tests", command=self.update_ui)
+        filemenu.add_command(label="Save and Close", command=self.export_and_close)
+        menubar.add_cascade(label="File", menu=filemenu)
 
-        self.canvas.bind("<Enter>", lambda e: self._set_scroll_target("canvas"))
-        self.canvas.bind("<Leave>", lambda e: self._set_scroll_target(None))
+        helpmenu = tk.Menu(menubar, tearoff=0)
+        helpmenu.add_command(label="Info", command=self.show_info)
+        menubar.add_cascade(label="Help", menu=helpmenu)
 
-        # Mouse scroll
+        viewmenu = tk.Menu(menubar, tearoff=0)
+        viewmenu.add_command(label="Reset zoom", command=self.canvas_view.reset_zoom_and_positions)
+        menubar.add_cascade(label="View", menu=viewmenu)
+
+        self.root.config(menu=menubar)
+
+        # Scroll & zoom bindings
         self.root.bind_all("<MouseWheel>", self._on_mousewheel)
         self.root.bind_all("<Shift-MouseWheel>", self._on_mousewheel)
-        self.root.bind_all("<Button-4>", self._on_mousewheel)  # Linux up
-        self.root.bind_all("<Button-5>", self._on_mousewheel)  # Linux down
+        self.root.bind_all("<Button-4>", self._on_mousewheel)
+        self.root.bind_all("<Button-5>", self._on_mousewheel)
+        self.canvas.bind_all("<Control-MouseWheel>", self._on_canvas_zoom)
+
+        self.active_scroll_target = None
+        self.canvas.bind("<Enter>", lambda e: self._set_scroll_target("canvas"))
+        self.canvas.bind("<Leave>", lambda e: self._set_scroll_target(None))
+        self.tree_view.tree.bind("<Enter>", lambda e: self._set_scroll_target("tree"))
+        self.tree_view.tree.bind("<Leave>", lambda e: self._set_scroll_target(None))
 
         self.draw_dependencies(self.default_test_cases)
-
 
     def _set_scroll_target(self, target):
         self.active_scroll_target = target
 
-
     def _on_mousewheel(self, event):
-        is_shift = (event.state & 0x0001) != 0  # Shift = bit 0x0001
+        is_shift = (event.state & 0x0001) != 0
+        delta = -1 if event.num == 5 or event.delta < 0 else 1
 
-        if event.num in (4, 5):  # Linux
-            direction = -1 if event.num == 4 else 1
-            if self.active_scroll_target == "canvas":
-                self.canvas.yview_scroll(direction, "units")
-            elif self.active_scroll_target == "tree":
-                self.tree.yview_scroll(direction, "units")
-            return
-
-        # Windows/macOS (MouseWheel)
-        delta = int(event.delta / 120)
         if self.active_scroll_target == "canvas":
             if is_shift:
-                self.canvas.xview_scroll(-delta, "units")
+                self.canvas.xview_scroll(delta, "units")
             else:
-                self.canvas.yview_scroll(-delta, "units")
+                self.canvas.yview_scroll(delta, "units")
         elif self.active_scroll_target == "tree":
-            if not is_shift:
-                self.tree.yview_scroll(-delta, "units")
+            self.tree_view.tree.yview_scroll(delta, "units")
+            self.tree_view.tree.yview_scroll(delta, "units")
 
-
-    def _bind_canvas_scroll(self, event=None):
-        self.canvas.bind_all("<MouseWheel>", self._on_canvas_scroll)
-        self.canvas.bind_all("<Button-4>", self._on_canvas_scroll)  # Linux support
-        self.canvas.bind_all("<Button-5>", self._on_canvas_scroll)
-
-
-    def _unbind_canvas_scroll(self, event=None):
-        self.canvas.unbind_all("<MouseWheel>")
-        self.canvas.unbind_all("<Button-4>")
-        self.canvas.unbind_all("<Button-5>")
-
-
-    def _on_canvas_scroll(self, event):
-        if event.delta:
-            self.canvas.yview_scroll(-1 * int(event.delta / 120), "units")
-        elif event.num == 4:  # Linux: scroll up
-            self.canvas.yview_scroll(-1, "units")
-        elif event.num == 5:  # Linux: scroll down
-            self.canvas.yview_scroll(1, "units")
-
-
-    def build_tree(self):
-        self.tree_nodes = {}  # path -> item_id
-        for test_name in self.test_order:
-            parts = test_name.split('.')
-            path = ""
-            parent = ""
-            for i, part in enumerate(parts):
-                path = '.'.join(parts[:i + 1])
-                if path not in self.tree_nodes:
-                    label = part
-                    node_id = self.tree.insert(parent, "end", text=f"[ ] {label}", open=True)
-                    self.tree_nodes[path] = node_id
-                parent = self.tree_nodes[path]
-
-            # Last part is test itself
-            var = tk.BooleanVar(value=(test_name in self.default_test_cases))
-            self.test_vars[test_name] = var
-
-            display_text = f"[ ] {parts[-1]}"
-            if var.get():
-                display_text = f"[x] {parts[-1]}"
-            self.tree.item(self.tree_nodes[path], text=display_text)
-
-            self.tree.tag_bind(test_name, '<Button-1>', lambda e, name=test_name: self.toggle_checkbox(name))
-
-        # Click events on whole tree
-        self.tree.bind("<Button-1>", self.on_tree_click)
-
-
-    def on_tree_click(self, event):
-        item_id = self.tree.identify_row(event.y)
-        if not item_id:
-            return
-
-        full_path = self.get_full_path(item_id)
-
-        # Prevent checkbox toggle if clicked to the far left (on top of expander)
-        if event.x < 20 * len(full_path.split(".")):
-            return
-        
-        # Checking whether the tests include
-        if full_path in self.test_vars:
-            self.toggle_checkbox(full_path)
-        else:
-            self.toggle_group_checkbox(item_id)
-        self.update_ui()
-
-
-    def toggle_checkbox(self, test_name):
-        var = self.test_vars[test_name]
-        var.set(not var.get())
-        item_id = self.tree_nodes[test_name]
-        new_state = "[x]" if var.get() else "[ ]"
-        label = test_name.split('.')[-1]
-        self.tree.item(item_id, text=f"{new_state} {label}")
-
-
-    def toggle_group_checkbox(self, item_id):
-        # Determine the selected status (x or no)
-        current_text = self.tree.item(item_id, "text")
-        new_state = not current_text.strip().startswith("[x]")
-
-        # Update current node
-        self.update_tree_item_checkbox(item_id, new_state)
-
-        # Recursively update all child nodes
-        def update_children_recursive(parent_id):
-            for child_id in self.tree.get_children(parent_id):
-                self.update_tree_item_checkbox(child_id, new_state)
-                update_children_recursive(child_id)
-
-        update_children_recursive(item_id)
-
-
-    def update_tree_item_checkbox(self, item_id, state):
-        full_path = self.get_full_path(item_id)
-        label = self.tree.item(item_id, "text").replace("[x] ", "").replace("[ ] ", "").strip()
-
-        # Update view
-        self.tree.item(item_id, text=f"[x] {label}" if state else f"[ ] {label}")
-
-        # If it is a correct test, update the var
-        if full_path in self.test_vars:
-            self.test_vars[full_path].set(state)
-
-
-    def update_checkbox_display_recursive(self, item_id):
-        text = self.tree.item(item_id, "text")
-        full_path = self.get_full_path(item_id)
-        if full_path in self.test_vars:
-            var = self.test_vars[full_path]
-            new_text = text.replace("[x]", "[ ]").replace("[ ]", "[x]" if var.get() else "[ ]")
-            self.tree.item(item_id, text=new_text)
-
-        for child_id in self.tree.get_children(item_id):
-            self.update_checkbox_display_recursive(child_id)
-
-
-    def get_full_path(self, item_id):
-        parts = []
-        while item_id:
-            raw_text = self.tree.item(item_id, "text")
-            clean_text = raw_text.replace("[ ] ", "").replace("[x] ", "")
-            parts.insert(0, clean_text)
-            item_id = self.tree.parent(item_id)
-        return '.'.join(parts)
-
-
-    def parse_tests_file(self, data):        
-        lines = data.strip().split('\n')
-        for line in lines:
-            line = line.strip()
-            if line.startswith('--test'):
-                data = line.split("--test ")[1].split("#DEPENDS")
-                test_name = data[0].strip()
-                deps = []
-                for n in range(1, len(data)):
-                    deps.append(data[n].strip())
-                #print("test name:", test_name)
-                self.tests[test_name] = {"name": test_name, "dependencies": deps}
-                self.test_order.append(test_name)
-            
-
-    def build_check_buttons(self):
-        # Create checkboxes for all tests
-        self.checkbuttons = {}
-        for idx, test_name in enumerate(self.test_order):
-            var = tk.BooleanVar()
-            cb = tk.Checkbutton(self.check_frame, text=test_name, variable=var)
-            cb.grid(row=idx, sticky='w')
-            self.checkbuttons[test_name] = var
-
-
-    def draw_dependencies(self, selected_tests_original):
-        self.current_selected_tests = selected_tests_original.copy()
-        self.canvas.delete("all")
-
-        x_spacing = 200
-        y_spacing = 80
-        x_start = 100
-        y_start = 50
-        row_spacing = 200
-
-        positions = {}
-
-        def collect_with_dependencies(test, collected):
-            if test in collected:
-                return
-            collected.add(test)
-            for dep in self.tests.get(test, {}).get("dependencies", []):
-                if dep in self.tests:
-                    collect_with_dependencies(dep, collected)
-
-        full_selected = set()
-        for test in selected_tests_original:
-            collect_with_dependencies(test, full_selected)
-
-        visited = set()
-        groups = []
-
-        def dfs_group(test, group):
-            if test in visited:
-                return
-            visited.add(test)
-            group.add(test)
-            for dep in self.tests.get(test, {}).get("dependencies", []):
-                if dep in full_selected:
-                    dfs_group(dep, group)
-            for t in full_selected:
-                if test in self.tests.get(t, {}).get("dependencies", []):
-                    dfs_group(t, group)
-
-        ungrouped = full_selected.copy()
-        while ungrouped:
-            group = set()
-            dfs_group(next(iter(ungrouped)), group)
-            groups.append(group)
-            ungrouped -= group
-
-        # Sort groups by size descending, but collect individual ones separately
-        individual_tests = [g for g in groups if len(g) == 1]
-        grouped_tests = [g for g in groups if len(g) > 1]
-        grouped_tests.sort(key=lambda g: -len(g))
-
-        individual_group = set.union(*individual_tests) if individual_tests else set()
-        sorted_groups = grouped_tests
-        if individual_group:
-            sorted_groups.append(individual_group) 
-
-        color_palette = ["lightblue", "lightgreen", "lightyellow", "lightpink", "lightgray", "#FFD580", "#B0E0E6"]
-        current_y = y_start
-
-        for idx, group in enumerate(sorted_groups):
-            group_color = color_palette[idx % len(color_palette)]
-
-            if not any(t in selected_tests_original for t in group):
-                continue
-
-            group_level_map = {}
-            def compute_level(test, visited):
-                if test in visited:
-                    return 0
-                visited.add(test)
-                if not self.tests[test]["dependencies"]:
-                    return 0
-                return 1 + max(compute_level(dep, visited.copy()) for dep in self.tests[test]["dependencies"] if dep in full_selected)
-
-            for test in group:
-                group_level_map[test] = compute_level(test, set())
-
-            level_tests = {}
-            for test in group:
-                level = group_level_map[test]
-                level_tests.setdefault(level, []).append(test)
-
-            max_height = max(len(tests) for tests in level_tests.values())
-            level_y_offsets = {lvl: current_y for lvl in level_tests}
-
-            # Group title
-            if individual_group and group == individual_group:
-                group_name = "Individual Test Cases"
-            else:
-                group_name = f"Group {idx + 1}"
-            self.canvas.create_text(x_start - 100, current_y - 100,
-                                    text=f"{group_name} ({len(group)} tests)",
-                                    anchor="w", font=("Arial", 14, "bold"))
-
-            for level in sorted(level_tests):
-                for test in sorted(level_tests[level]):
-                    x = x_start + level * x_spacing
-                    y = level_y_offsets[level]
-                    positions[test] = (x, y)
-                    box = self.canvas.create_rectangle(x - 60, y - 20, x + 60, y + 20, fill=group_color)
-                    display_text = self.shorten_text_to_fit(test.split('.')[-1], 100 * self.canvas_scale)
-                    label = self.canvas.create_text(x, y, text=display_text)
-
-                    self.canvas.tag_bind(box, "<Enter>", lambda e, t=test: self.show_tooltip(e, t))
-                    self.canvas.tag_bind(box, "<Leave>", self.hide_tooltip)
-                    self.canvas.tag_bind(label, "<Enter>", lambda e, t=test: self.show_tooltip(e, t))
-                    self.canvas.tag_bind(label, "<Leave>", self.hide_tooltip)
-
-                    level_y_offsets[level] += y_spacing
-
-            # Arrows
-            for test in group:
-                for dep in self.tests[test]["dependencies"]:
-                    if dep in group:
-                        x1, y1 = positions[test]
-                        x2, y2 = positions[dep]
-                        self.canvas.create_line(x1 - 60, y1, x2 + 60, y2, arrow=tk.LAST)
-
-            current_y += (max_height + 1) * y_spacing + row_spacing
-
-        # Show total count
-        self.total_selected_label.config(text=f"Total Selected Tests: {len(full_selected)}")
-        self.all_current_selected_test_cases = full_selected
-
-        self.canvas.scale("all", 0, 0, self.canvas_scale, self.canvas_scale)
-        self.canvas.config(scrollregion=self.canvas.bbox("all"))
-
-
-    def shorten_text_to_fit(self, text, max_width, font=("TkDefaultFont", 10)):
-        test_id = self.canvas.create_text(0, 0, text=text, font=font, anchor="nw", tags="temp")
-        bbox = self.canvas.bbox(test_id)
-        self.canvas.delete(test_id)
-
-        if not bbox:
-            return text  # fallback if font measuring fails
-
-        width = bbox[2] - bbox[0]
-        if width <= max_width:
-            return text
-
-        # Shorten the text until it fits
-        for i in range(len(text), 0, -1):
-            shortened = text[:i] + "..."
-            test_id = self.canvas.create_text(0, 0, text=shortened, font=font, anchor="nw", tags="temp")
-            bbox = self.canvas.bbox(test_id)
-            self.canvas.delete(test_id)
-
-            if bbox and (bbox[2] - bbox[0]) <= max_width:
-                return shortened
-
-        return "..."  # fallback if nothing works
-
-
-    def reset_zoom(self):
-        self.canvas_scale = 1.0
-        self._update_zoom_label()
-        self.draw_dependencies(self.current_selected_tests)
-
-
-    def show_info(self):
-        messagebox.showinfo("Instructions", "\n- Select tests from the tree on the left.\n- Selected tests and their dependencies will be drawn on the right.\n- If you select a test, its prerequisites will be automatically selected.\n- Close and save selections by clicking \"Save and Close\".")
-
-
-    def show_tooltip(self, event, text):
-        if self.tooltip:
-            self.canvas.delete(self.tooltip)
-            self.tooltip = None
-        x = self.canvas.canvasx(event.x)
-        y = self.canvas.canvasy(event.y)
-        self.tooltip = self.canvas.create_text(x + 10, y + 10, anchor="nw", text=text, tag="tooltip", fill="black", font=("Arial", 10))
-
-
-    def hide_tooltip(self, event=None):
-        if self.tooltip:
-            self.canvas.delete(self.tooltip)
-            self.tooltip = None
-
-
-    def _on_key_zoom_in(self):
-        current = self.canvas_scale
-        for level in self.zoom_levels:
-            if level > current:
-                self._zoom_canvas_direct(level)
-                break
-
-
-    def _on_key_zoom_out(self):
-        current = self.canvas_scale
-        for level in reversed(self.zoom_levels):
-            if level < current:
-                self._zoom_canvas_direct(level)
-                break
-
-
-    def _zoom_canvas_direct(self, new_scale):
-        if new_scale == self.canvas_scale:
-            return
-
-        self.canvas_scale = new_scale
-        self._update_zoom_label()
-        self.draw_dependencies(self.current_selected_tests)
-        self.canvas.config(scrollregion=self.canvas.bbox("all"))
-
-    
     def _on_canvas_zoom(self, event):
         zoom_factor = 1.1 if event.delta > 0 else 0.9
-        old_scale = self.canvas_scale
-        new_scale = old_scale * zoom_factor
-        new_scale = max(0.2, min(4.0, new_scale))
+        old_scale = self.canvas_view.scale
+        new_scale = max(0.2, min(4.0, old_scale * zoom_factor))
+        self.canvas_view.set_zoom(new_scale)
 
-        if abs(new_scale - old_scale) < 0.001:
-            return
+    def parse_tests_file(self, data):
+        lines = data.strip().split('\n')
+        for line in lines:
+            if line.strip().startswith('--test'):
+                parts = line.split("--test ")[1].split("#DEPENDS")
+                test_name = parts[0].strip()
+                deps = [d.strip() for d in parts[1:]]
+                self.tests[test_name] = {"name": test_name, "dependencies": deps}
+                self.test_order.append(test_name)
 
-        canvas_mouse_x = self.canvas.canvasx(event.x)
-        canvas_mouse_y = self.canvas.canvasy(event.y)
-
-        bbox = self.canvas.bbox("all")
-        if not bbox:
-            return
-
-        content_width = bbox[2] - bbox[0]
-        content_height = bbox[3] - bbox[1]
-
-        rel_x = (canvas_mouse_x - bbox[0]) / max(content_width, 1)
-        rel_y = (canvas_mouse_y - bbox[1]) / max(content_height, 1)
-
-        self.canvas_scale = new_scale
-        self._update_zoom_label()
-        self.draw_dependencies(self.current_selected_tests)
-
-        bbox = self.canvas.bbox("all")
-        if bbox:
-            new_width = bbox[2] - bbox[0]
-            new_height = bbox[3] - bbox[1]
-
-            new_x = bbox[0] + rel_x * new_width
-            new_y = bbox[1] + rel_y * new_height
-
-            self.canvas.xview_moveto((new_x - self.canvas.winfo_width() / 2) / max(new_width, 1))
-            self.canvas.yview_moveto((new_y - self.canvas.winfo_height() / 2) / max(new_height, 1))
-
-        self.canvas.config(scrollregion=self.canvas.bbox("all"))
-
-    
-    def zoom_to_fit(self):
-        bbox = self.canvas.bbox("all")
-        if not bbox:
-            return
-
-        canvas_width = self.canvas.winfo_width()
-        canvas_height = self.canvas.winfo_height()
-
-        content_width = bbox[2] - bbox[0]
-        content_height = bbox[3] - bbox[1]
-
-        if content_width == 0 or content_height == 0:
-            return
-
-        scale_x = canvas_width / content_width
-        scale_y = canvas_height / content_height
-
-        fit_scale = min(scale_x, scale_y)
-        fit_scale = max(0.2, min(4.0, fit_scale))
-
-        self.canvas_scale = fit_scale
-        self._update_zoom_label()
-        self.draw_dependencies(self.current_selected_tests)
-
-        self.canvas.xview_moveto(0)
-        self.canvas.yview_moveto(0)
-
-
-    def _update_zoom_label(self):
-        percent = int(self.canvas_scale * 100)
-        self.zoom_label.config(text=f"Zoom: {percent}%")
-
+    def draw_dependencies(self, selected_tests):
+        self.current_selected_tests = selected_tests.copy()
+        self.dependency_manager = DependencyCanvasManager(self.canvas, self.tests, self.current_selected_tests)
+        self.canvas_view.register_boxes(list(self.dependency_manager.boxes.values()))
 
     def update_ui(self):
         selected = [name for name, var in self.test_vars.items() if var.get()]
         self.draw_dependencies(selected)
 
+    def show_info(self):
+        messagebox.showinfo("Instructions",
+            "- Select tests from the tree on the left.\n"
+            "- Selected tests and their dependencies will be drawn on the right.\n"
+            "- Close and save selections by clicking \"Save and Close\".")
 
     def export_and_close(self):
-        self.selected_tests_result = list(self.all_current_selected_test_cases)
+        self.selected_tests_result = list(self.dependency_manager.boxes.keys())
         self.root.destroy()
 
 
@@ -590,7 +161,6 @@ def main_application(data, default_test_cases):
     root.mainloop()
     selected_tests = getattr(app, "selected_tests_result", None)
     return selected_tests
-
 
 
 if __name__ == "__main__":

--- a/src/DependencySolver/ui_canvas.py
+++ b/src/DependencySolver/ui_canvas.py
@@ -1,0 +1,370 @@
+import tkinter as tk
+from tkinter import ttk
+
+
+class GroupLabel:
+    def __init__(self, canvas, name, y):
+        self.canvas = canvas
+        self.name = name
+        self.logical_y = y
+        self.item = canvas.create_text(0, 0, text=name, anchor="w", font=("Arial", 12, "bold"), tags="group_label")
+
+    def redraw(self):
+        scale = getattr(self.canvas.canvas_view, 'scale', 1.0)
+        self.canvas.coords(self.item, 10, self.logical_y * scale)
+
+
+class DraggableTestBox:
+    def __init__(self, canvas, test_name, x, y, width=120, height=40, fill="lightblue"):
+        self.canvas = canvas
+        self.test_name = test_name
+        self.display_name = test_name.split('.')[-1]
+        self.width = width
+        self.height = height
+        self.fill = fill
+        self.original_x = x
+        self.original_y = y
+        self.logical_x = x  # logical (unscaled) coordinates
+        self.logical_y = y
+        self.group_bounds = None  # tuple (min_y, max_y)
+
+        self.rect = canvas.create_rectangle(0, 0, 0, 0, fill=fill, tags="box")
+        self.text = canvas.create_text(0, 0, text="", tags="box")
+
+        self.arrows_out = []
+        self.arrows_in = []
+
+        self.canvas.tag_bind(self.rect, "<ButtonPress-1>", self.start_drag)
+        self.canvas.tag_bind(self.text, "<ButtonPress-1>", self.start_drag)
+        self.canvas.tag_bind(self.rect, "<B1-Motion>", self.drag_y_only)
+        self.canvas.tag_bind(self.text, "<B1-Motion>", self.drag_y_only)
+        self.canvas.tag_bind(self.rect, "<ButtonRelease-1>", self.end_drag)
+        self.canvas.tag_bind(self.text, "<ButtonRelease-1>", self.end_drag)
+
+        self.canvas.tag_bind(self.rect, "<Enter>", self.show_tooltip)
+        self.canvas.tag_bind(self.text, "<Enter>", self.show_tooltip)
+        self.canvas.tag_bind(self.rect, "<Leave>", self.hide_tooltip)
+        self.canvas.tag_bind(self.text, "<Leave>", self.hide_tooltip)
+
+        self.set_position(x, y)
+
+    def shorten_text(self):
+        zoom = getattr(self.canvas.canvas_view, 'scale', 1.0)
+        max_chars = int(self.width * zoom / 8)
+        return self.display_name if len(self.display_name) <= max_chars else self.display_name[:max_chars - 3] + "..."
+
+    def update_text(self):
+        short = self.shorten_text()
+        self.canvas.itemconfig(self.text, text=short)
+
+    def start_drag(self, event):
+        self.drag_offset_y = self.canvas.canvasy(event.y) - self.get_screen_y()
+        self.canvas.canvas_view.push_undo()
+
+    def drag_y_only(self, event):
+        new_screen_y = self.canvas.canvasy(event.y) - self.drag_offset_y
+        scale = getattr(self.canvas.canvas_view, 'scale', 1.0)
+        new_logical_y = new_screen_y / scale
+
+        if self.group_bounds:
+            min_y, max_y = self.group_bounds
+            new_logical_y = max(min_y, min(max_y, new_logical_y))
+
+        self.logical_y = new_logical_y
+        self.redraw()
+
+    def end_drag(self, event):
+        self.update_arrows()
+
+    def redraw(self):
+        scale = getattr(self.canvas.canvas_view, 'scale', 1.0)
+        x = self.logical_x * scale
+        y = self.logical_y * scale
+        w = self.width * scale
+        h = self.height * scale
+        self.canvas.coords(self.rect, x - w / 2, y - h / 2, x + w / 2, y + h / 2)
+        self.canvas.coords(self.text, x, y)
+        self.update_text()
+        self.update_arrows()
+
+    def get_screen_x(self):
+        scale = getattr(self.canvas.canvas_view, 'scale', 1.0)
+        return self.logical_x * scale
+
+    def get_screen_y(self):
+        scale = getattr(self.canvas.canvas_view, 'scale', 1.0)
+        return self.logical_y * scale
+
+    def set_position(self, x, y):
+        self.logical_x = x
+        self.logical_y = y
+        self.redraw()
+
+    def set_group_bounds(self, min_y, max_y):
+        self.group_bounds = (min_y, max_y)
+
+    def reset_position(self):
+        self.set_position(self.original_x, self.original_y)
+
+    def update_arrows(self):
+        for arrow in self.arrows_out + self.arrows_in:
+            arrow.update_position()
+
+    def show_tooltip(self, event):
+        if hasattr(self.canvas, 'tooltip') and self.canvas.tooltip:
+            self.canvas.delete(self.canvas.tooltip)
+        x = self.canvas.canvasx(event.x)
+        y = self.canvas.canvasy(event.y)
+        self.canvas.tooltip = self.canvas.create_text(x + 10, y + 10, anchor="nw", text=self.test_name, tag="tooltip", fill="black", font=("Arial", 10))
+
+    def hide_tooltip(self, event):
+        if hasattr(self.canvas, 'tooltip') and self.canvas.tooltip:
+            self.canvas.delete(self.canvas.tooltip)
+            self.canvas.tooltip = None
+
+
+class TestArrow:
+    def __init__(self, canvas, from_box: DraggableTestBox, to_box: DraggableTestBox):
+        self.canvas = canvas
+        self.from_box = from_box
+        self.to_box = to_box
+        self.line = canvas.create_line(0, 0, 0, 0, arrow=tk.LAST, fill="black", width=2)
+        from_box.arrows_out.append(self)
+        to_box.arrows_in.append(self)
+        self.update_position()
+
+    def update_position(self):
+        scale = getattr(self.canvas.canvas_view, 'scale', 1.0)
+        fx = self.from_box.get_screen_x() - (self.from_box.width * scale) / 2
+        fy = self.from_box.get_screen_y()
+        tx = self.to_box.get_screen_x() + (self.to_box.width * scale) / 2
+        ty = self.to_box.get_screen_y()
+        self.canvas.coords(self.line, fx, fy, tx, ty)
+
+
+class CanvasView:
+    def __init__(self, canvas, zoom_label):
+        self.canvas = canvas
+        self.zoom_label = zoom_label
+        self.scale = 1.0
+        self.zoom_levels = [0.2 + i * 0.1 for i in range(39)]
+        self.canvas.tooltip = None
+        self.boxes = []
+        self.undo_stack = []
+        self.redo_stack = []
+        self.counter_label = None
+
+    def zoom_in(self):
+        current = self.scale
+        for level in self.zoom_levels:
+            if level > current:
+                self.set_zoom(level)
+                break
+
+    def zoom_out(self):
+        current = self.scale
+        for level in reversed(self.zoom_levels):
+            if level < current:
+                self.set_zoom(level)
+                break
+
+    def set_zoom(self, new_scale):
+        if new_scale == self.scale:
+            return
+        self.scale = new_scale
+        for box in self.boxes:
+            box.redraw()
+        self.redraw_labels()
+        self.canvas.config(scrollregion=self.canvas.bbox("all"))
+        self.update_label()
+
+    def zoom_to_fit(self):
+        bbox = self.canvas.bbox("all")
+        if not bbox:
+            return
+        w = self.canvas.winfo_width()
+        h = self.canvas.winfo_height()
+        bw = bbox[2] - bbox[0]
+        bh = bbox[3] - bbox[1]
+        if bw == 0 or bh == 0:
+            return
+        fit_scale = min(w / bw, h / bh)
+        fit_scale = max(0.2, min(4.0, fit_scale))
+        self.set_zoom(fit_scale)
+
+    def reset_zoom_and_positions(self):
+        self.set_zoom(1.0)
+        for box in self.boxes:
+            box.reset_position()
+        self.canvas.config(scrollregion=self.canvas.bbox("all"))
+    
+    def update_label(self):
+        self.zoom_label.config(text=f"Zoom: {int(self.scale * 100)}%")
+        if self.counter_label:
+            count = 0
+            if hasattr(self.canvas, "dependency_manager") and hasattr(self.canvas.dependency_manager, "get_total_tests"):
+                count = self.canvas.dependency_manager.get_total_tests()
+            else:
+                count = len(self.boxes)
+            self.counter_label.config(text=f"Total Selected Tests: {count}")
+
+    def register_boxes(self, boxes):
+        self.boxes = boxes
+        for box in self.boxes:
+            box.update_text()
+        self.update_label()
+
+    def set_counter_label(self, label):
+        self.counter_label = label
+
+    def push_undo(self):
+        state = [(box.test_name, box.logical_x, box.logical_y) for box in self.boxes]
+        self.undo_stack.append(state)
+        self.redo_stack.clear()
+
+    def undo(self):
+        if not self.undo_stack:
+            return
+        state = self.undo_stack.pop()
+        self.redo_stack.append([(box.test_name, box.logical_x, box.logical_y) for box in self.boxes])
+        self.restore_state(state)
+
+    def redo(self):
+        if not self.redo_stack:
+            return
+        state = self.redo_stack.pop()
+        self.undo_stack.append([(box.test_name, box.logical_x, box.logical_y) for box in self.boxes])
+        self.restore_state(state)
+
+    def restore_state(self, state):
+        box_map = {box.test_name: box for box in self.boxes}
+        for name, x, y in state:
+            if name in box_map:
+                box_map[name].set_position(x, y)
+        self.canvas.config(scrollregion=self.canvas.bbox("all"))
+
+    def redraw_labels(self):
+        if hasattr(self.canvas, "dependency_manager"):
+            for label in self.canvas.dependency_manager.labels:
+                label.redraw()
+
+
+class DependencyCanvasManager():
+    def __init__(self, canvas, tests, selected_tests):
+        self.canvas = canvas
+        self.tests = tests
+        self.selected_tests = selected_tests
+        self.boxes = {}
+        self.labels = []
+        self.build_canvas()
+        self.canvas.dependency_manager = self
+
+    def get_total_tests(self):
+        return sum(len(group) for group in self.groups)
+
+    def build_canvas(self):
+        self.canvas.delete("all")
+        x_spacing = 200
+        y_spacing = 80
+        x_start = 150
+        y_start = 100
+        row_spacing = 100
+        color_palette = ["lightblue", "lightgreen", "lightyellow", "lightpink", "lightgray", "#FFD580", "#B0E0E6"]
+
+        def collect_with_dependencies(test, collected):
+            if test in collected:
+                return
+            collected.add(test)
+            for dep in self.tests.get(test, {}).get("dependencies", []):
+                if dep in self.tests:
+                    collect_with_dependencies(dep, collected)
+
+        full_selected = set()
+        for test in self.selected_tests:
+            collect_with_dependencies(test, full_selected)
+
+        visited = set()
+        self.groups = []
+
+        def dfs_group(test, group):
+            if test in visited:
+                return
+            visited.add(test)
+            group.add(test)
+            for dep in self.tests.get(test, {}).get("dependencies", []):
+                if dep in full_selected:
+                    dfs_group(dep, group)
+            for t in full_selected:
+                if test in self.tests.get(t, {}).get("dependencies", []):
+                    dfs_group(t, group)
+
+        ungrouped = full_selected.copy()
+        while ungrouped:
+            group = set()
+            dfs_group(next(iter(ungrouped)), group)
+            self.groups.append(group)
+            ungrouped -= group
+
+        individual_tests = [g for g in self.groups if len(g) == 1]
+        grouped_tests = [g for g in self.groups if len(g) > 1]
+        grouped_tests.sort(key=lambda g: -len(g))
+
+        individual_group = set.union(*individual_tests) if individual_tests else set()
+        sorted_groups = grouped_tests
+        if individual_group:
+            sorted_groups.append(individual_group) 
+
+        current_y = y_start
+        for idx, group in enumerate(grouped_tests):
+            group_color = color_palette[idx % len(color_palette)]
+            if not any(t in self.selected_tests for t in group):
+                continue
+
+            level_map = {}
+
+            def compute_level(test, visited):
+                if test in visited:
+                    return 0
+                visited.add(test)
+                if not self.tests[test]["dependencies"]:
+                    return 0
+                return 1 + max(compute_level(dep, visited.copy()) for dep in self.tests[test]["dependencies"] if dep in full_selected)
+
+            for test in group:
+                level_map[test] = compute_level(test, set())
+
+            level_tests = {}
+            for test in group:
+                level = level_map[test]
+                level_tests.setdefault(level, []).append(test)
+
+            max_height = max(len(tests) for tests in level_tests.values())
+            level_y_offsets = {lvl: current_y for lvl in level_tests}
+
+            group_name = "Individual Test Cases" if individual_group and group == individual_group else f"Group {idx + 1}"
+
+            label = GroupLabel(self.canvas, f"{group_name} ({len(group)} tests)", current_y - 50)
+            self.labels.append(label)
+            label.redraw()
+
+            for level in sorted(level_tests):
+                for test in sorted(level_tests[level]):
+                    x = x_start + level * x_spacing
+                    y = level_y_offsets[level]
+                    box = DraggableTestBox(self.canvas, test, x, y, fill=group_color)
+                    box.set_group_bounds(
+                        min_y=(current_y - 10),
+                        max_y=(current_y + (max_height + 1) * y_spacing)
+                    )
+                    self.boxes[test] = box
+                    level_y_offsets[level] += y_spacing
+
+            for test in group:
+                for dep in self.tests[test]["dependencies"]:
+                    if dep in self.boxes and self.boxes[dep].logical_x < self.boxes[test].logical_x:
+                        TestArrow(self.canvas, self.boxes[test], self.boxes[dep])
+
+            current_y += (max_height + 1) * y_spacing + row_spacing
+
+        self.canvas.config(scrollregion=self.canvas.bbox("all"))
+        self.canvas.tooltip = None

--- a/src/DependencySolver/ui_treeview.py
+++ b/src/DependencySolver/ui_treeview.py
@@ -1,0 +1,92 @@
+import tkinter as tk
+from tkinter import ttk
+
+
+class TestTreeView:
+    def __init__(self, parent, test_order, test_vars, default_test_cases, on_selection_change):
+        self.frame = ttk.Frame(parent)
+        self.frame.pack(side=tk.LEFT, fill=tk.Y, padx=10, pady=10, expand=True)
+
+        self.scroll_y = ttk.Scrollbar(self.frame, orient="vertical")
+        self.tree = ttk.Treeview(self.frame, yscrollcommand=self.scroll_y.set)
+        self.tree.heading("#0", text="Test Cases")
+
+        self.scroll_y.config(command=self.tree.yview)
+
+        self.tree.grid(row=0, column=0, sticky="nsew")
+        self.scroll_y.grid(row=0, column=1, sticky="ns")
+        self.frame.grid_rowconfigure(0, weight=1)
+        self.frame.grid_columnconfigure(0, weight=1)
+
+        self.test_order = test_order
+        self.test_vars = test_vars
+        self.tree_nodes = {}
+        self.on_selection_change = on_selection_change
+
+        self.build_tree(default_test_cases)
+
+        self.tree.bind("<Button-1>", self.on_tree_click)
+
+    def build_tree(self, default_test_cases):
+        for test_name in self.test_order:
+            parts = test_name.split('.')
+            path = ""
+            parent = ""
+            for i, part in enumerate(parts):
+                path = '.'.join(parts[:i + 1])
+                if path not in self.tree_nodes:
+                    node_id = self.tree.insert(parent, "end", text=f"[ ] {part}", open=True)
+                    self.tree_nodes[path] = node_id
+                parent = self.tree_nodes[path]
+
+            var = tk.BooleanVar(value=(test_name in default_test_cases))
+            self.test_vars[test_name] = var
+            label = parts[-1]
+            self.tree.item(self.tree_nodes[path], text=f"[x] {label}" if var.get() else f"[ ] {label}")
+
+    def on_tree_click(self, event):
+        item_id = self.tree.identify_row(event.y)
+        if not item_id:
+            return
+
+        full_path = self.get_full_path(item_id)
+        if event.x < 20 * len(full_path.split(".")):
+            return
+
+        if full_path in self.test_vars:
+            self.toggle_checkbox(full_path)
+        else:
+            self.toggle_group_checkbox(item_id)
+        self.on_selection_change()
+
+    def toggle_checkbox(self, test_name):
+        var = self.test_vars[test_name]
+        var.set(not var.get())
+        item_id = self.tree_nodes[test_name]
+        new_state = "[x]" if var.get() else "[ ]"
+        label = test_name.split('.')[-1]
+        self.tree.item(item_id, text=f"{new_state} {label}")
+
+    def toggle_group_checkbox(self, item_id):
+        current_text = self.tree.item(item_id, "text")
+        new_state = not current_text.strip().startswith("[x]")
+        self.update_tree_item_checkbox(item_id, new_state)
+
+        for child_id in self.tree.get_children(item_id):
+            self.toggle_group_checkbox(child_id)
+
+    def update_tree_item_checkbox(self, item_id, state):
+        full_path = self.get_full_path(item_id)
+        label = self.tree.item(item_id, "text").replace("[x] ", "").replace("[ ] ", "").strip()
+        self.tree.item(item_id, text=f"[x] {label}" if state else f"[ ] {label}")
+        if full_path in self.test_vars:
+            self.test_vars[full_path].set(state)
+
+    def get_full_path(self, item_id):
+        parts = []
+        while item_id:
+            raw_text = self.tree.item(item_id, "text")
+            clean_text = raw_text.replace("[x] ", "").replace("[ ] ", "")
+            parts.insert(0, clean_text)
+            item_id = self.tree.parent(item_id)
+        return '.'.join(parts)

--- a/tests/data_13/suite_a.robot
+++ b/tests/data_13/suite_a.robot
@@ -1,0 +1,92 @@
+*** Settings ***
+Test Tags    ALL
+Library    DependencyLibrary
+
+*** Variables ***
+# These variables will present a whole system global state in this simple example.
+${TEXT}    Nothing done yet.
+${TEXT1}    Nothing done yet.
+${TEXT2}    Nothing done yet.
+${TEXT3}    Nothing done yet.
+
+*** Test Cases ***
+Test A1
+    [Tags]    A1
+    Should Be Equal    first=${TEXT}    second=Nothing done yet.
+    VAR    ${TEXT}    A1 ready.    scope=GLOBAL
+    Should Be Equal    first=${TEXT}    second=A1 ready.
+
+Test A2
+    [Tags]    A2
+    [Setup]    Depends On Test    name=Test A1
+    Should Be Equal    first=${TEXT}    second=A1 ready.
+    VAR    ${TEXT}    A2 ready.    scope=GLOBAL
+    Should Be Equal    first=${TEXT}    second=A2 ready.
+
+Test A3
+    [Tags]    A3
+    [Setup]    Depends On Test    name=Test A2
+    Should Be Equal    first=${TEXT}    second=A2 ready.
+    VAR    ${TEXT}    A3 ready.    scope=GLOBAL
+    Should Be Equal    first=${TEXT}    second=A3 ready.
+
+Test A4
+    [Tags]    A4
+    [Setup]    Depends On Test    name=Test A3
+    Should Be Equal    first=${TEXT}    second=A3 ready.
+    VAR    ${TEXT}    A4 ready.    scope=GLOBAL
+    Should Be Equal    first=${TEXT}    second=A4 ready.
+
+Test A5
+    [Tags]    A5
+    Log    This test is independent.
+
+Test A6
+    [Tags]    A6
+    Log    This test is independent.
+
+Test A7
+    [Tags]    A7
+    Log    This test is independent.
+
+Test A8
+    [Tags]    A8
+    Should Be Equal    first=${TEXT1}    second=Nothing done yet.
+    Should Be Equal    first=${TEXT2}    second=Nothing done yet.
+    Should Be Equal    first=${TEXT3}    second=Nothing done yet.
+    VAR    ${TEXT1}    A8 ready.    scope=GLOBAL
+    VAR    ${TEXT2}    A8 ready.    scope=GLOBAL
+    VAR    ${TEXT3}    A8 ready.    scope=GLOBAL
+    Should Be Equal    first=${TEXT1}    second=A8 ready.
+    Should Be Equal    first=${TEXT2}    second=A8 ready.
+    Should Be Equal    first=${TEXT3}    second=A8 ready.
+
+Test A9
+    [Tags]    A9
+    [Setup]    Depends On Test    name=Test A8
+    Should Be Equal    first=${TEXT1}    second=A8 ready.
+    VAR    ${TEXT1}    A9 ready.    scope=GLOBAL
+    Should Be Equal    first=${TEXT1}    second=A9 ready.
+
+Test A10
+    [Tags]    A10
+    [Setup]    Depends On Test    name=Test A8
+    Should Be Equal    first=${TEXT2}    second=A8 ready.
+    VAR    ${TEXT2}    A10 ready.    scope=GLOBAL
+    Should Be Equal    first=${TEXT2}    second=A10 ready.
+
+Test A11
+    [Tags]    A11
+    [Setup]    Depends On Test    name=Test A8
+    Should Be Equal    first=${TEXT3}    second=A8 ready.
+    VAR    ${TEXT3}    A11 ready.    scope=GLOBAL
+    Should Be Equal    first=${TEXT3}    second=A11 ready.
+
+Test A12
+    [Tags]    A12
+    [Setup]    Run Keywords    Depends On Test    name=Test A9
+    ...    AND    Depends On Test    name=Test A10
+    ...    AND    Depends On Test    name=Test A11
+    Should Be Equal    first=${TEXT1}    second=A9 ready.
+    Should Be Equal    first=${TEXT2}    second=A10 ready.
+    Should Be Equal    first=${TEXT3}    second=A11 ready.

--- a/tests/test_reflogs/TestA3.log
+++ b/tests/test_reflogs/TestA3.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--test', 'TestA3', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--test', 'TestA3', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 1'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 1.suiteA'

--- a/tests/test_reflogs/TestA6.log
+++ b/tests/test_reflogs/TestA6.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--test', 'TestA6', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--test', 'TestA6', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 1'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 1.suiteA'

--- a/tests/test_reflogs/TestB3.log
+++ b/tests/test_reflogs/TestB3.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'B3', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'B3', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 1'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 1.suiteA'

--- a/tests/test_reflogs/TestB5.log
+++ b/tests/test_reflogs/TestB5.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'testB', '--exclude', 'B6', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'testB', '--exclude', 'B6', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 1'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 1.suiteA'

--- a/tests/test_reflogs/complicated_call.log
+++ b/tests/test_reflogs/complicated_call.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--test', 'suite*.T*t[AB]?', '--test', 'Test[!Bb]1', '--test', 'Test[AB][!2-6]', '--suite', 'data_1.*[Aa]', '--include', 'allANDAORtestBNOTt3', '--include', 't1ANDallANDA', '--exclude', 'allANDt2', '--exclude', 'NOT[AB]1', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--test', 'suite*.T*t[AB]?', '--test', 'Test[!Bb]1', '--test', 'Test[AB][!2-6]', '--suite', 'data_1.*[Aa]', '--include', 'allANDAORtestBNOTt3', '--include', 't1ANDallANDA', '--exclude', 'allANDt2', '--exclude', 'NOT[AB]1', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 1'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 1.suiteA'

--- a/tests/test_reflogs/exclude_explicit.log
+++ b/tests/test_reflogs/exclude_explicit.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'A2', '--exclude_explicit', 'A1', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'A2', '--exclude_explicit', 'A1', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 1'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 1.suiteA'

--- a/tests/test_reflogs/exclude_tag_name_not_exist.log
+++ b/tests/test_reflogs/exclude_tag_name_not_exist.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--exclude', 'tag_not_exist', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--exclude', 'tag_not_exist', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 3'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 3.suiteC'

--- a/tests/test_reflogs/keyword_in_suite_setup.log
+++ b/tests/test_reflogs/keyword_in_suite_setup.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--suite', 'suite O', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--suite', 'suite O', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 11'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 11.suite A'

--- a/tests/test_reflogs/loop.log
+++ b/tests/test_reflogs/loop.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'C2', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'C2', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 2'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 2.suiteC'

--- a/tests/test_reflogs/not_exist.log
+++ b/tests/test_reflogs/not_exist.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'C2', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'C2', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 3'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 3.suiteC'

--- a/tests/test_reflogs/not_unambigous.log
+++ b/tests/test_reflogs/not_unambigous.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'A2', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'A2', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 10'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 10.suite A'

--- a/tests/test_reflogs/pabot_grouping.log
+++ b/tests/test_reflogs/pabot_grouping.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'ALL', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'ALL', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 8'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 8.suiteA'

--- a/tests/test_reflogs/rerun.log
+++ b/tests/test_reflogs/rerun.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'ALL', '--rerun', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'ALL', '--rerun', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ INFO ] Rerunner started
 [ DEBUG ] Re-running test case 'Data 7.Subsuite A.suite D.Test D1'
 [ DEBUG ] Re-running test case 'Data 7.Subsuite A.suite G.Test G1'

--- a/tests/test_reflogs/robot_test_setup.log
+++ b/tests/test_reflogs/robot_test_setup.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'B4', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'B4', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 9'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 9.suiteA'

--- a/tests/test_reflogs/self_loop.log
+++ b/tests/test_reflogs/self_loop.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'testC', '--exclude', 'C1', '--exclude', 'C2', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'testC', '--exclude', 'C1', '--exclude', 'C2', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 2'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 2.suiteC'

--- a/tests/test_reflogs/suite_duplicate.log
+++ b/tests/test_reflogs/suite_duplicate.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'D', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'D', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 6'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 6.Subsuite'

--- a/tests/test_reflogs/suite_loop.log
+++ b/tests/test_reflogs/suite_loop.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'E', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'E', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 4'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 4.suiteD'

--- a/tests/test_reflogs/suite_name_not_exist.log
+++ b/tests/test_reflogs/suite_name_not_exist.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--suite', 'suite_not_exist', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--suite', 'suite_not_exist', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 3'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 3.suiteC'

--- a/tests/test_reflogs/suite_not_exist.log
+++ b/tests/test_reflogs/suite_not_exist.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--suite', 'suiteC', '--exclude', 'C2', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--suite', 'suiteC', '--exclude', 'C2', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 3'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 3.suiteC'

--- a/tests/test_reflogs/tag_name_not_exist.log
+++ b/tests/test_reflogs/tag_name_not_exist.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'tag_not_exist', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'tag_not_exist', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 3'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 3.suiteC'

--- a/tests/test_reflogs/test_duplicate.log
+++ b/tests/test_reflogs/test_duplicate.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'D2', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'D2', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 5'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 5.suiteD'

--- a/tests/test_reflogs/test_name_not_exist.log
+++ b/tests/test_reflogs/test_name_not_exist.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--test', 'test_not_exist', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--test', 'test_not_exist', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'Data 3'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Investigating subsuite 'Data 3.suiteC'

--- a/tests/test_reflogs/test_names.log
+++ b/tests/test_reflogs/test_names.log
@@ -1,4 +1,4 @@
-[ INFO ] The following arguments were obtained: ('--include', 'ALL', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
+[ INFO ] The following arguments were obtained: ('--include', 'ALL', '--randomize', 'NONE', '--debug', '--without_timestamps', '--fileloglevel', 'DEBUG', '--consoleloglevel', 'INFO', '--pabotlevel', 'FULL')
 [ DEBUG ] Started suite: 'suite A'
 [ INFO ] Starting to explore the dependencies...
 [ DEBUG ] Requested test 'suite A.Test A 1' because of --include option: 'ALL'


### PR DESCRIPTION
This PR introduces two new command-line options to the Dependency Solver:

- `--randomize`: Enables randomized test order. 
  - A custom random seed can be provided using the syntax VALUE;SEED, where the seed must be an integer. Since the general delimiter for prerunmodifier arguments is `:`, unlike in the Robot Framework syntax, a semicolon `;` must be used as the delimiter instead. 
  - Closes #5 

- `--ui`: Launches a simple UI that allows users to:
  - Select tests via a tree view
  - Visualize test dependencies using arrows
  - Closes #6 

> **Note:** The UI is currently in Beta. Feedback and bug reports are welcome. Its documentation will also be improved in future updates.  
